### PR TITLE
Add search box for topics

### DIFF
--- a/AvaloniaApp/AvaloniaApp/Views/TopicsPanel.axaml
+++ b/AvaloniaApp/AvaloniaApp/Views/TopicsPanel.axaml
@@ -4,18 +4,21 @@
              xmlns:vm="clr-namespace:KafkaLens.ViewModels;assembly=KafkaLens.ViewModels"
              xmlns:av="clr-namespace:Avalonia.Controls;assembly=Avalonia.Controls"
              x:DataType="vm:OpenedClusterViewModel">
-    <TreeView Name="TopicsTree" ItemsSource="{Binding Children}"
-              SelectedItem="{Binding SelectedNode}">
-        <TreeView.Styles>
-            <Style Selector="av|TreeViewItem" x:DataType="vm:ITreeNode">
-                <Setter Property="IsSelected" Value="{Binding IsSelected}"/>
-                <Setter Property="IsExpanded" Value="{Binding IsExpanded}"/>
-            </Style>
-        </TreeView.Styles>
-        <TreeView.ItemTemplate>
-            <TreeDataTemplate x:DataType="vm:ITreeNode" ItemsSource="{Binding Children}">
-                <TextBlock Text="{Binding Name}" Margin="0" FontSize="12"/>
-            </TreeDataTemplate>
-        </TreeView.ItemTemplate>
-    </TreeView>
+    <Grid RowDefinitions="Auto,*">
+        <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}" Watermark="Filter topics..." Margin="5"/>
+        <TreeView Grid.Row="1" Name="TopicsTree" ItemsSource="{Binding Children}"
+                  SelectedItem="{Binding SelectedNode}">
+            <TreeView.Styles>
+                <Style Selector="av|TreeViewItem" x:DataType="vm:ITreeNode">
+                    <Setter Property="IsSelected" Value="{Binding IsSelected}"/>
+                    <Setter Property="IsExpanded" Value="{Binding IsExpanded}"/>
+                </Style>
+            </TreeView.Styles>
+            <TreeView.ItemTemplate>
+                <TreeDataTemplate x:DataType="vm:ITreeNode" ItemsSource="{Binding Children}">
+                    <TextBlock Text="{Binding Name}" Margin="0" FontSize="12"/>
+                </TreeDataTemplate>
+            </TreeView.ItemTemplate>
+        </TreeView>
+    </Grid>
 </UserControl>

--- a/ViewModels/OpenedClusterViewModel.cs
+++ b/ViewModels/OpenedClusterViewModel.cs
@@ -240,7 +240,27 @@ public partial class OpenedClusterViewModel : ViewModelBase, ITreeNode
         {
             var viewModel = new TopicViewModel(topic, null);
             Topics.Add(viewModel);
-            Children.Add(viewModel);
+        }
+        FilterTopics();
+    }
+
+    [ObservableProperty]
+    private string filterText = "";
+
+    partial void OnFilterTextChanged(string value)
+    {
+        FilterTopics();
+    }
+
+    private void FilterTopics()
+    {
+        Children.Clear();
+        foreach (var topic in Topics)
+        {
+            if (string.IsNullOrWhiteSpace(FilterText) || topic.Name.Contains(FilterText, StringComparison.OrdinalIgnoreCase))
+            {
+                Children.Add(topic);
+            }
         }
     }
 


### PR DESCRIPTION
This change adds a search box to the topic list in the `OpenedClusterViewModel` and `TopicsPanel`. This allows users to filter the list of topics by name. The filtering is case-insensitive and updates immediately as the user types.

The `OpenedClusterViewModel` now maintains two collections:
- `Topics`: The complete list of topics loaded from the cluster.
- `Children`: The filtered list of topics displayed in the `TreeView`.

The `FilterText` property triggers the `FilterTopics` method, which clears and repopulates the `Children` collection based on the filter.

---
*PR created automatically by Jules for task [10008907189567680415](https://jules.google.com/task/10008907189567680415) started by @fatichar*