### PR TITLE
Fix issues #34 and #35: Disable panels when no selection

### DIFF
--- a/AvaloniaApp/AvaloniaApp/Views/FetchPanel.axaml
+++ b/AvaloniaApp/AvaloniaApp/Views/FetchPanel.axaml
@@ -8,7 +8,8 @@
         <avaloniaApp:FetchPositionConverter x:Key="IsTimestampPosition" />
     </UserControl.Resources>
     <Grid Margin="5" RowDefinitions="Auto, Auto, Auto, Auto, *" ColumnDefinitions="Auto, *"
-          VerticalAlignment="Top">
+          VerticalAlignment="Top"
+          IsEnabled="{Binding IsFetchOptionsEnabled}">
         <Label Grid.Row="0" Grid.Column="0"
                VerticalAlignment="Center"
                Margin="5">

--- a/AvaloniaApp/AvaloniaApp/Views/MessageDisplayToolbar.axaml
+++ b/AvaloniaApp/AvaloniaApp/Views/MessageDisplayToolbar.axaml
@@ -3,7 +3,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:vm="clr-namespace:KafkaLens.ViewModels;assembly=KafkaLens.ViewModels"
 	x:DataType="vm:OpenedClusterViewModel">
-	<Grid>
+	<Grid IsEnabled="{Binding CurrentMessages.IsMessageSelected}">
 		<Grid.ColumnDefinitions>
 			<ColumnDefinition Width="Auto"/>
 			<ColumnDefinition Width="*"/>

--- a/ViewModels/MessagesViewModel.cs
+++ b/ViewModels/MessagesViewModel.cs
@@ -40,6 +40,7 @@ public sealed class MessagesViewModel: ViewModelBase
             }
             if (SetProperty(ref currentMessage, value))
             {
+                OnPropertyChanged(nameof(IsMessageSelected));
                 if (currentMessage != null)
                 {
                     currentMessage.LineFilter = lineFilter;
@@ -48,6 +49,8 @@ public sealed class MessagesViewModel: ViewModelBase
             }
         }
     }
+
+    public bool IsMessageSelected => CurrentMessage != null;
 
     private string positiveFilter = "";
     public string PositiveFilter

--- a/ViewModels/OpenedClusterViewModel.cs
+++ b/ViewModels/OpenedClusterViewModel.cs
@@ -64,8 +64,16 @@ public partial class OpenedClusterViewModel : ViewModelBase, ITreeNode
     public ITreeNode.NodeType SelectedNodeType
     {
         get;
-        set => SetProperty(ref field, value);
+        set
+        {
+            if (SetProperty(ref field, value))
+            {
+                OnPropertyChanged(nameof(IsFetchOptionsEnabled));
+            }
+        }
     } = ITreeNode.NodeType.NONE;
+
+    public bool IsFetchOptionsEnabled => SelectedNodeType == ITreeNode.NodeType.TOPIC || SelectedNodeType == ITreeNode.NodeType.PARTITION;
 
     public int[] FetchCounts => new int[] { 10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 25000 };
     public int FetchCount { get; set; } = 10;


### PR DESCRIPTION
This PR addresses GitHub issues #34 and #35.
- Issue #34: Disable Fetch options panel when no topic/partition is selected.
- Issue #35: Disable message display toolbar when no message is selected.

The changes involve adding boolean properties to the corresponding ViewModels that track the selection state and binding the `IsEnabled` property of the root containers in the UI to these properties. This ensures that users cannot interact with these panels when they are not applicable.

---
*PR created automatically by Jules for task [11974525494720105843](https://jules.google.com/task/11974525494720105843) started by @fatichar*