### PR TITLE
Fix UI fit and finish issues

### DIFF
--- a/AvaloniaApp/AvaloniaApp/Views/AddEditClientDialog.axaml
+++ b/AvaloniaApp/AvaloniaApp/Views/AddEditClientDialog.axaml
@@ -4,23 +4,27 @@
         Title="Add/Edit Client"
         Width="400" Height="350"
         WindowStartupLocation="CenterOwner">
-    <StackPanel Margin="20" Spacing="10">
-        <Label Content="Client Name"/>
-        <TextBox Name="NameBox" Watermark="e.g. MyClient"/>
+    <Grid Margin="20" RowDefinitions="*, Auto">
+        <ScrollViewer Grid.Row="0">
+            <StackPanel Spacing="10">
+                <Label Content="Client Name"/>
+                <TextBox Name="NameBox" Watermark="e.g. MyClient"/>
 
-        <Label Content="Address"/>
-        <TextBox Name="AddressBox" Watermark="e.g. localhost:5000"/>
+                <Label Content="Address"/>
+                <TextBox Name="AddressBox" Watermark="e.g. localhost:5000"/>
 
-        <Label Content="Protocol"/>
-        <ComboBox Name="ProtocolBox" SelectedIndex="0" HorizontalAlignment="Stretch">
-            <ComboBoxItem Content="grpc"/>
-        </ComboBox>
+                <Label Content="Protocol"/>
+                <ComboBox Name="ProtocolBox" SelectedIndex="0" HorizontalAlignment="Stretch">
+                    <ComboBoxItem Content="grpc"/>
+                </ComboBox>
 
-        <TextBlock Name="ErrorTextBlock" Foreground="{DynamicResource ThemeErrorBrush}" TextWrapping="Wrap" Margin="0,10,0,0"/>
+                <TextBlock Name="ErrorTextBlock" Foreground="{DynamicResource ThemeErrorBrush}" TextWrapping="Wrap" Margin="0,10,0,0"/>
+            </StackPanel>
+        </ScrollViewer>
 
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10" Margin="0,20,0,0">
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10" Margin="0,20,0,0">
             <Button Name="OkButton" Content="OK" IsDefault="True" Click="OkButton_Click"/>
             <Button Name="CancelButton" Content="Cancel" IsCancel="True" Click="CancelButton_Click"/>
         </StackPanel>
-    </StackPanel>
+    </Grid>
 </Window>

--- a/AvaloniaApp/AvaloniaApp/Views/AddEditClusterDialog.axaml
+++ b/AvaloniaApp/AvaloniaApp/Views/AddEditClusterDialog.axaml
@@ -4,20 +4,24 @@
         Title="Add/Edit Cluster"
         Width="400" Height="300"
         WindowStartupLocation="CenterOwner">
-    <StackPanel Margin="20" Spacing="10">
-        <Label Content="Cluster Name"/>
-        <TextBox Name="NameBox" Watermark="e.g. Production"/>
+    <Grid Margin="20" RowDefinitions="*, Auto">
+        <ScrollViewer Grid.Row="0">
+            <StackPanel Spacing="10">
+                <Label Content="Cluster Name"/>
+                <TextBox Name="NameBox" Watermark="e.g. Production"/>
 
-        <Label Content="Bootstrap Servers"/>
-        <TextBox Name="AddressBox" Watermark="e.g. localhost:9092"/>
+                <Label Content="Bootstrap Servers"/>
+                <TextBox Name="AddressBox" Watermark="e.g. localhost:9092"/>
 
-        <TextBlock Name="ErrorTextBlock" Foreground="{DynamicResource ThemeErrorBrush}" TextWrapping="Wrap" Margin="0,10,0,0"/>
-        <TextBlock Name="StatusTextBlock" Foreground="{DynamicResource StatusConnectedBrush}" TextWrapping="Wrap" Margin="0,5,0,0"/>
+                <TextBlock Name="ErrorTextBlock" Foreground="{DynamicResource ThemeErrorBrush}" TextWrapping="Wrap" Margin="0,10,0,0"/>
+                <TextBlock Name="StatusTextBlock" Foreground="{DynamicResource StatusConnectedBrush}" TextWrapping="Wrap" Margin="0,5,0,0"/>
+            </StackPanel>
+        </ScrollViewer>
 
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10" Margin="0,20,0,0">
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10" Margin="0,20,0,0">
             <Button Name="TestButton" Content="Test Connection" Click="TestButton_Click" IsVisible="False"/>
             <Button Name="OkButton" Content="OK" IsDefault="True" Click="OkButton_Click"/>
             <Button Name="CancelButton" Content="Cancel" IsCancel="True" Click="CancelButton_Click"/>
         </StackPanel>
-    </StackPanel>
+    </Grid>
 </Window>

--- a/AvaloniaApp/AvaloniaApp/Views/FetchPanel.axaml
+++ b/AvaloniaApp/AvaloniaApp/Views/FetchPanel.axaml
@@ -82,7 +82,7 @@
             <Button Content="Fetch Messages" Command="{Binding FetchMessagesCommand}"
                     Grid.Column="0"
                     HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"
-                    Height="30" Margin="0,0,5,0" />
+                    Height="30" Margin="0,0,5,0" MinWidth="120" />
             <Button Content="Stop" Command="{Binding StopLoadingCommand}"
                     Grid.Column="1"
                     HorizontalAlignment="Stretch" HorizontalContentAlignment="Center"


### PR DESCRIPTION
Improved the UI layout of the Add/Edit Cluster and Client dialogs by using a Grid with a ScrollViewer, ensuring that the action buttons are always visible at the bottom and respect the window margins. Also fixed a text truncation issue on the "Fetch Messages" button in the FetchPanel by setting a minimum width.

---
*PR created automatically by Jules for task [18110868666475436848](https://jules.google.com/task/18110868666475436848) started by @fatichar*