### PR TITLE
Improve Formatter Selection #42

### DIFF
--- a/AvaloniaApp/AvaloniaApp/App.axaml.cs
+++ b/AvaloniaApp/AvaloniaApp/App.axaml.cs
@@ -59,6 +59,9 @@ public partial class App : Application
         var settingsFilePath = Path.Combine(kafkaLensDataPath, "settings.json");
         services.AddSingleton<ISettingsService>(new SettingsService(settingsFilePath));
 
+        var topicSettingsFilePath = Path.Combine(kafkaLensDataPath, "topic_settings.json");
+        services.AddSingleton<ITopicSettingsService>(new TopicSettingsService(topicSettingsFilePath));
+
         var pluginsPath = Path.Combine(kafkaLensDataPath, "Plugins");
         var pluginsDir = Directory.CreateDirectory(pluginsPath);
         AddLocalDependencies(services, clusterRepo, pluginsDir);

--- a/AvaloniaApp/AvaloniaApp/NodeTypeConverter.cs
+++ b/AvaloniaApp/AvaloniaApp/NodeTypeConverter.cs
@@ -1,0 +1,23 @@
+using Avalonia.Data.Converters;
+using KafkaLens.ViewModels;
+using System;
+using System.Globalization;
+
+namespace AvaloniaApp;
+
+public class NodeTypeConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is ITreeNode.NodeType nodeType && parameter is string target)
+        {
+            return nodeType.ToString().Equals(target, StringComparison.OrdinalIgnoreCase);
+        }
+        return false;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/AvaloniaApp/AvaloniaApp/Views/Browser.axaml
+++ b/AvaloniaApp/AvaloniaApp/Views/Browser.axaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:KafkaLens.ViewModels;assembly=KafkaLens.ViewModels"
              xmlns:views="clr-namespace:AvaloniaApp.Views"
+             xmlns:avaloniaApp="clr-namespace:AvaloniaApp"
              xmlns:avaloniaEdit="https://github.com/avaloniaui/avaloniaedit"
              x:DataType="vm:OpenedClusterViewModel">
     <UserControl.Resources>
@@ -16,52 +17,63 @@
                 <MenuItem Header="As Formatted" Command="{Binding SaveAllAsFormattedCommand}"/>
             </MenuItem>
         </ContextMenu>
+        <avaloniaApp:NodeTypeConverter x:Key="IsNodeType" />
     </UserControl.Resources>
-    <Grid RowDefinitions="*, 3, *">
-        <DockPanel Margin="0">
-            <views:MessagesToolbar x:Name="MessagesToolbar" DockPanel.Dock="Top"
-                                   HorizontalAlignment="Stretch"
-                                   Background="{DynamicResource ThemeToolbarBackgroundBrush}" BorderThickness="0">
-            </views:MessagesToolbar>
+    <TabControl BorderThickness="0,1,0,0">
+        <TabItem Header="Messages">
+            <Grid RowDefinitions="*, 3, *">
+                <DockPanel Margin="0">
+                    <views:MessagesToolbar x:Name="MessagesToolbar" DockPanel.Dock="Top"
+                                           HorizontalAlignment="Stretch"
+                                           Background="{DynamicResource ThemeToolbarBackgroundBrush}" BorderThickness="0">
+                    </views:MessagesToolbar>
 
-            <DataGrid Name="MessagesGrid" AutoGenerateColumns="False" HeadersVisibility="All"
-                      HorizontalAlignment="Stretch"
-                      CanUserReorderColumns="True"
-                      CanUserResizeColumns="True"
-                      LoadingRow="messagesGrid_LoadingRow"
-                      CanUserSortColumns="True"
-                      RowHeaderWidth="50"
-                      IsReadOnly="True"
-                      ItemsSource="{Binding CurrentMessages.Filtered}"
-                      SelectedItem="{Binding CurrentMessages.CurrentMessage, Mode=TwoWay}"
-                      SelectionChanged="MessagesGrid_OnSelectionChanged"
-                      ContextMenu="{StaticResource MessageGridContextMenu}">
-                <DataGrid.Columns>
-                    <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Partition"
-                                        Binding="{Binding Partition }" />
-                    <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Offset" Binding="{Binding Offset}" />
-                    <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Timestamp"
-                                        Binding="{Binding Timestamp}" />
-                    <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Key" Binding="{Binding Key }" />
-                    <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Body" Binding="{Binding Summary }" />
-                </DataGrid.Columns>
-                <DataGrid.RowDetailsTemplate></DataGrid.RowDetailsTemplate>
-            </DataGrid>
-        </DockPanel>
+                    <DataGrid Name="MessagesGrid" AutoGenerateColumns="False" HeadersVisibility="All"
+                              HorizontalAlignment="Stretch"
+                              CanUserReorderColumns="True"
+                              CanUserResizeColumns="True"
+                              LoadingRow="messagesGrid_LoadingRow"
+                              CanUserSortColumns="True"
+                              RowHeaderWidth="50"
+                              IsReadOnly="True"
+                              ItemsSource="{Binding CurrentMessages.Filtered}"
+                              SelectedItem="{Binding CurrentMessages.CurrentMessage, Mode=TwoWay}"
+                              SelectionChanged="MessagesGrid_OnSelectionChanged"
+                              ContextMenu="{StaticResource MessageGridContextMenu}">
+                        <DataGrid.Columns>
+                            <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Partition"
+                                                Binding="{Binding Partition }" />
+                            <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Offset" Binding="{Binding Offset}" />
+                            <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Timestamp"
+                                                Binding="{Binding Timestamp}" />
+                            <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Key" Binding="{Binding Key }" />
+                            <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Body" Binding="{Binding Summary }" />
+                        </DataGrid.Columns>
+                        <DataGrid.RowDetailsTemplate></DataGrid.RowDetailsTemplate>
+                    </DataGrid>
+                </DockPanel>
 
-        <GridSplitter Grid.Row="1" Background="{DynamicResource ThemeGridSplitterBrush}" />
+                <GridSplitter Grid.Row="1" Background="{DynamicResource ThemeGridSplitterBrush}" />
 
-        <DockPanel Grid.Row="2">
-            <views:MessageDisplayToolbar x:Name="MessageDisplayToolbar" DockPanel.Dock="Bottom"
-                                         VerticalAlignment="Center" HorizontalAlignment="Stretch"
-                                         Background="{DynamicResource ThemeToolbarBackgroundBrush}" BorderThickness="1" BorderBrush="{DynamicResource ThemeBorderBrush}">
-            </views:MessageDisplayToolbar>
-            <avaloniaEdit:TextEditor
-                Name="MessageViewer"
-                FontFamily="Consolas"
-                FontSize="{Binding FontSize}"
-                IsReadOnly="True"
-                />
-        </DockPanel>
-    </Grid>
+                <DockPanel Grid.Row="2">
+                    <views:MessageDisplayToolbar x:Name="MessageDisplayToolbar" DockPanel.Dock="Bottom"
+                                                 VerticalAlignment="Center" HorizontalAlignment="Stretch"
+                                                 Background="{DynamicResource ThemeToolbarBackgroundBrush}" BorderThickness="1" BorderBrush="{DynamicResource ThemeBorderBrush}">
+                    </views:MessageDisplayToolbar>
+                    <avaloniaEdit:TextEditor
+                        Name="MessageViewer"
+                        FontFamily="Consolas"
+                        FontSize="{Binding FontSize}"
+                        IsReadOnly="True"
+                        />
+                </DockPanel>
+            </Grid>
+        </TabItem>
+        <TabItem Header="Configuration">
+            <Panel>
+                <views:TopicConfigView IsVisible="{Binding SelectedNodeType, Converter={StaticResource IsNodeType}, ConverterParameter=TOPIC}"/>
+                <views:PartitionConfigView IsVisible="{Binding SelectedNodeType, Converter={StaticResource IsNodeType}, ConverterParameter=PARTITION}"/>
+            </Panel>
+        </TabItem>
+    </TabControl>
 </UserControl>

--- a/AvaloniaApp/AvaloniaApp/Views/PartitionConfigView.axaml
+++ b/AvaloniaApp/AvaloniaApp/Views/PartitionConfigView.axaml
@@ -1,0 +1,16 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:KafkaLens.ViewModels;assembly=KafkaLens.ViewModels"
+             x:Class="AvaloniaApp.Views.PartitionConfigView"
+             x:DataType="vm:OpenedClusterViewModel">
+    <StackPanel Margin="20" Spacing="10">
+        <TextBlock Text="Partition Configuration" FontSize="18" FontWeight="Bold"/>
+
+        <Grid ColumnDefinitions="Auto, *" RowDefinitions="Auto, Auto" Margin="0,10,0,0">
+            <Label Grid.Row="0" Grid.Column="0" Content="Partition:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+            <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding SelectedNode.Name}" VerticalAlignment="Center"/>
+        </Grid>
+
+        <TextBlock Text="No configuration available for partitions." Margin="0,20,0,0" FontStyle="Italic"/>
+    </StackPanel>
+</UserControl>

--- a/AvaloniaApp/AvaloniaApp/Views/PartitionConfigView.axaml.cs
+++ b/AvaloniaApp/AvaloniaApp/Views/PartitionConfigView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace AvaloniaApp.Views;
+
+public partial class PartitionConfigView : UserControl
+{
+    public PartitionConfigView()
+    {
+        InitializeComponent();
+    }
+}

--- a/AvaloniaApp/AvaloniaApp/Views/TopicConfigView.axaml
+++ b/AvaloniaApp/AvaloniaApp/Views/TopicConfigView.axaml
@@ -1,0 +1,30 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:KafkaLens.ViewModels;assembly=KafkaLens.ViewModels"
+             x:Class="AvaloniaApp.Views.TopicConfigView"
+             x:DataType="vm:OpenedClusterViewModel">
+    <StackPanel Margin="20" Spacing="10">
+        <TextBlock Text="Topic Configuration" FontSize="18" FontWeight="Bold"/>
+
+        <Grid ColumnDefinitions="Auto, *" RowDefinitions="Auto, Auto, Auto, Auto" Margin="0,10,0,0">
+            <Label Grid.Row="0" Grid.Column="0" Content="Topic Name:" VerticalAlignment="Center" Margin="0,0,10,0"/>
+            <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding SelectedNode.Name}" VerticalAlignment="Center"/>
+
+            <Label Grid.Row="1" Grid.Column="0" Content="Key Formatter:" VerticalAlignment="Center" Margin="0,10,10,0"/>
+            <ComboBox Grid.Row="1" Grid.Column="1" Margin="0,10,0,0" HorizontalAlignment="Stretch"
+                      ItemsSource="{Binding KeyFormatterNames}"
+                      SelectedItem="{Binding ((vm:IMessageSource)SelectedNode).KeyFormatterName}"/>
+
+            <Label Grid.Row="2" Grid.Column="0" Content="Value Formatter:" VerticalAlignment="Center" Margin="0,10,10,0"/>
+            <ComboBox Grid.Row="2" Grid.Column="1" Margin="0,10,0,0" HorizontalAlignment="Stretch"
+                      ItemsSource="{Binding TopicFormatterNames}"
+                      SelectedItem="{Binding ((vm:IMessageSource)SelectedNode).FormatterName}"/>
+
+            <CheckBox Grid.Row="3" Grid.Column="1" Content="Apply to every cluster"
+                      Margin="0,10,0,0" IsChecked="{Binding ApplyToAllClusters}"/>
+        </Grid>
+
+        <Button Content="Save" Command="{Binding SaveTopicSettingsCommand}"
+                HorizontalAlignment="Right" Width="100" Margin="0,20,0,0"/>
+    </StackPanel>
+</UserControl>

--- a/AvaloniaApp/AvaloniaApp/Views/TopicConfigView.axaml.cs
+++ b/AvaloniaApp/AvaloniaApp/Views/TopicConfigView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace AvaloniaApp.Views;
+
+public partial class TopicConfigView : UserControl
+{
+    public TopicConfigView()
+    {
+        InitializeComponent();
+    }
+}

--- a/Core.Tests/Core.Tests.csproj
+++ b/Core.Tests/Core.Tests.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
     <ProjectReference Include="..\Shared\Shared.csproj" />
+    <ProjectReference Include="..\Formatting\Formatting.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Core.Tests/Formatting/NumberFormatterTests.cs
+++ b/Core.Tests/Formatting/NumberFormatterTests.cs
@@ -1,0 +1,33 @@
+using KafkaLens.Formatting;
+using Xunit;
+
+namespace Core.Tests.Formatting;
+
+public class NumberFormatterTests
+{
+    private readonly NumberFormatter formatter = new();
+
+    [Fact]
+    public void Format_Int32_BigEndian()
+    {
+        byte[] data = { 0x00, 0x00, 0x00, 0x2A }; // 42 in Big-Endian
+        var result = formatter.Format(data, true);
+        Assert.Equal("42", result);
+    }
+
+    [Fact]
+    public void Format_Int64_BigEndian()
+    {
+        byte[] data = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x2A }; // 42 in Big-Endian
+        var result = formatter.Format(data, true);
+        Assert.Equal("42", result);
+    }
+
+    [Fact]
+    public void Format_InvalidLength()
+    {
+        byte[] data = { 0x01, 0x02, 0x03 };
+        var result = formatter.Format(data, true);
+        Assert.Null(result);
+    }
+}

--- a/Formatting/FormatterFactory.cs
+++ b/Formatting/FormatterFactory.cs
@@ -9,6 +9,7 @@ public class FormatterFactory
     private readonly IDictionary<string, IMessageFormatter> formatters = new Dictionary<string, IMessageFormatter>();
     private const string Json = "Json";
     private const string Text = "Text";
+    private const string Number = "Number";
 
     static FormatterFactory()
     {
@@ -19,6 +20,7 @@ public class FormatterFactory
     {
         formatters.Add(Json, new JsonFormatter());
         formatters.Add(Text, new TextFormatter());
+        formatters.Add(Number, new NumberFormatter());
     }
 
     public IMessageFormatter DefaultFormatter => formatters[Json];

--- a/Formatting/NumberFormatter.cs
+++ b/Formatting/NumberFormatter.cs
@@ -1,0 +1,51 @@
+namespace KafkaLens.Formatting;
+
+public class NumberFormatter : IMessageFormatter
+{
+    public string Name => "Number";
+
+    public string? Format(byte[] data, bool prettyPrint)
+    {
+        if (data == null || data.Length == 0)
+        {
+            return null;
+        }
+
+        try
+        {
+            byte[] clone = (byte[])data.Clone();
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(clone);
+            }
+
+            if (clone.Length == 4)
+            {
+                return BitConverter.ToInt32(clone, 0).ToString();
+            }
+            if (clone.Length == 8)
+            {
+                return BitConverter.ToInt64(clone, 0).ToString();
+            }
+            if (clone.Length == 2)
+            {
+                return BitConverter.ToInt16(clone, 0).ToString();
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+        return null;
+    }
+
+    public string? Format(byte[] data, string searchText, bool useObjectFilter = true)
+    {
+        var formatted = Format(data, true);
+        if (formatted != null && (string.IsNullOrEmpty(searchText) || formatted.Contains(searchText, StringComparison.OrdinalIgnoreCase)))
+        {
+            return formatted;
+        }
+        return null;
+    }
+}

--- a/ViewModels/IMessageSource.cs
+++ b/ViewModels/IMessageSource.cs
@@ -7,4 +7,5 @@ public interface IMessageSource : ITreeNode
 {
     ObservableCollection<MessageViewModel> Messages { get; }
     string? FormatterName { get; set; }
+    string? KeyFormatterName { get; set; }
 }

--- a/ViewModels/ITopicSettingsService.cs
+++ b/ViewModels/ITopicSettingsService.cs
@@ -1,0 +1,7 @@
+namespace KafkaLens.ViewModels;
+
+public interface ITopicSettingsService
+{
+    TopicSettings GetSettings(string clusterId, string topicName);
+    void SetSettings(string clusterId, string topicName, TopicSettings settings, bool applyToAllClusters = false);
+}

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -37,6 +37,7 @@ public partial class MainViewModel : ViewModelBase
     // services
     private readonly IClusterFactory clusterFactory;
     private readonly ISettingsService settingsService;
+    private readonly ITopicSettingsService topicSettingsService;
     private readonly ISavedMessagesClient savedMessagesClient;
     private DispatcherTimer timer;
 
@@ -86,6 +87,7 @@ public partial class MainViewModel : ViewModelBase
         AppConfig appConfig,
         IClusterFactory clusterFactory,
         ISettingsService settingsService,
+        ITopicSettingsService topicSettingsService,
         ISavedMessagesClient savedMessagesClient,
         IClusterInfoRepository clusterInfoRepository,
         IClientInfoRepository clientInfoRepository,
@@ -98,6 +100,7 @@ public partial class MainViewModel : ViewModelBase
         Log.Information("Creating MainViewModel");
         this.clusterFactory = clusterFactory;
         this.settingsService = settingsService;
+        this.topicSettingsService = topicSettingsService;
         this.savedMessagesClient = savedMessagesClient;
         OpenedClusterViewModel.FormatterFactory = formatterFactory;
 
@@ -373,7 +376,7 @@ public partial class MainViewModel : ViewModelBase
             newName = GenerateNewName(clusterViewModel.Name, alreadyOpened);
         }
 
-        var openedCluster = new OpenedClusterViewModel(settingsService, clusterViewModel, newName);
+        var openedCluster = new OpenedClusterViewModel(settingsService, topicSettingsService, clusterViewModel, newName);
         alreadyOpened.Add(openedCluster);
         OpenedClusters.Add(openedCluster);
         _ = openedCluster.LoadTopicsAsync();

--- a/ViewModels/MessageViewModel.cs
+++ b/ViewModels/MessageViewModel.cs
@@ -10,10 +10,11 @@ public sealed partial class MessageViewModel : ViewModelBase
 
     public readonly Message message;
     private IMessageFormatter formatter = null!;
+    private IMessageFormatter keyFormatter = null!;
 
     public int Partition => message.Partition;
     public long Offset => message.Offset;
-    public string? Key => message.KeyText;
+    [ObservableProperty] private string? key;
     public string Summary { get; set; } = null!;
     public string DecodedMessage { get; set; } = null!;
     public string FormattedMessage { get; set; } = null!;
@@ -48,10 +49,26 @@ public sealed partial class MessageViewModel : ViewModelBase
         }
     }
 
-    public MessageViewModel(Message message, string formatterName)
+    private string keyFormatterName = null!;
+
+    public string KeyFormatterName
+    {
+        get => keyFormatterName;
+        set
+        {
+            if (value == keyFormatterName) return;
+
+            SetProperty(ref keyFormatterName, value);
+            keyFormatter = FormatterFactory.Instance.GetFormatter(value);
+            Key = keyFormatter.Format(message.Key ?? Array.Empty<byte>(), false) ?? message.KeyText;
+        }
+    }
+
+    public MessageViewModel(Message message, string formatterName, string keyFormatterName)
     {
         this.message = message;
         FormatterName = formatterName;
+        KeyFormatterName = keyFormatterName;
 
         IsActive = true;
     }

--- a/ViewModels/PartitionViewModel.cs
+++ b/ViewModels/PartitionViewModel.cs
@@ -28,6 +28,10 @@ public partial class PartitionViewModel: ViewModelBase, IMessageSource {
         LoadMessagesCommand = new AsyncRelayCommand(LoadMessagesAsync);
         this.partition = partition;
         this.topic = topic;
+        this.topic.PropertyChanged += (s, e) => {
+            if (e.PropertyName == nameof(TopicViewModel.FormatterName)) OnPropertyChanged(nameof(FormatterName));
+            if (e.PropertyName == nameof(TopicViewModel.KeyFormatterName)) OnPropertyChanged(nameof(KeyFormatterName));
+        };
 
         IsActive = true;
     }
@@ -44,6 +48,12 @@ public partial class PartitionViewModel: ViewModelBase, IMessageSource {
     {
         get => topic.FormatterName;
         set => topic.FormatterName = value;
+    }
+
+    public string? KeyFormatterName
+    {
+        get => topic.KeyFormatterName;
+        set => topic.KeyFormatterName = value;
     }
 
     private Task LoadMessagesAsync() {

--- a/ViewModels/TopicSettings.cs
+++ b/ViewModels/TopicSettings.cs
@@ -1,0 +1,7 @@
+namespace KafkaLens.ViewModels;
+
+public class TopicSettings
+{
+    public string KeyFormatter { get; set; } = "Auto";
+    public string ValueFormatter { get; set; } = "Auto";
+}

--- a/ViewModels/TopicSettingsService.cs
+++ b/ViewModels/TopicSettingsService.cs
@@ -1,0 +1,118 @@
+using Newtonsoft.Json;
+using System.IO;
+
+namespace KafkaLens.ViewModels;
+
+public class TopicSettingsService : ITopicSettingsService
+{
+    private readonly string filePath;
+    // Map: ClusterId -> TopicName -> Settings
+    private Dictionary<string, Dictionary<string, TopicSettings>> clusterSettings = new();
+    // Map: TopicName -> Settings
+    private Dictionary<string, TopicSettings> globalSettings = new();
+
+    public TopicSettingsService(string filePath)
+    {
+        this.filePath = filePath;
+        Load();
+    }
+
+    private class PersistenceModel
+    {
+        public Dictionary<string, Dictionary<string, TopicSettings>> ClusterSettings { get; set; } = new();
+        public Dictionary<string, TopicSettings> GlobalSettings { get; set; } = new();
+    }
+
+    private void Load()
+    {
+        if (File.Exists(filePath))
+        {
+            try
+            {
+                var json = File.ReadAllText(filePath);
+                var model = JsonConvert.DeserializeObject<PersistenceModel>(json);
+                if (model != null)
+                {
+                    clusterSettings = model.ClusterSettings ?? new();
+                    globalSettings = model.GlobalSettings ?? new();
+                }
+            }
+            catch (Exception ex)
+            {
+                Serilog.Log.Error(ex, "Failed to load topic settings from {FilePath}", filePath);
+            }
+        }
+    }
+
+    private void Save()
+    {
+        try
+        {
+            var model = new PersistenceModel
+            {
+                ClusterSettings = clusterSettings,
+                GlobalSettings = globalSettings
+            };
+            var json = JsonConvert.SerializeObject(model, Newtonsoft.Json.Formatting.Indented);
+            var directory = Path.GetDirectoryName(filePath);
+            if (directory != null && !Directory.Exists(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+            File.WriteAllText(filePath, json);
+        }
+        catch (Exception ex)
+        {
+            Serilog.Log.Error(ex, "Failed to save topic settings to {FilePath}", filePath);
+        }
+    }
+
+    public TopicSettings GetSettings(string clusterId, string topicName)
+    {
+        if (clusterSettings.TryGetValue(clusterId, out var topicMap) && topicMap.TryGetValue(topicName, out var settings))
+        {
+            return new TopicSettings
+            {
+                KeyFormatter = settings.KeyFormatter,
+                ValueFormatter = settings.ValueFormatter
+            };
+        }
+
+        if (globalSettings.TryGetValue(topicName, out var globalSetting))
+        {
+            return new TopicSettings
+            {
+                KeyFormatter = globalSetting.KeyFormatter,
+                ValueFormatter = globalSetting.ValueFormatter
+            };
+        }
+
+        return new TopicSettings();
+    }
+
+    public void SetSettings(string clusterId, string topicName, TopicSettings settings, bool applyToAllClusters = false)
+    {
+        if (!clusterSettings.TryGetValue(clusterId, out var topicMap))
+        {
+            topicMap = new Dictionary<string, TopicSettings>();
+            clusterSettings[clusterId] = topicMap;
+        }
+
+        topicMap[topicName] = new TopicSettings
+        {
+            KeyFormatter = settings.KeyFormatter,
+            ValueFormatter = settings.ValueFormatter
+        };
+
+        if (applyToAllClusters)
+        {
+            globalSettings[topicName] = new TopicSettings
+            {
+                KeyFormatter = settings.KeyFormatter,
+                ValueFormatter = settings.ValueFormatter
+            };
+        }
+
+        Save();
+    }
+}

--- a/ViewModels/TopicViewModel.cs
+++ b/ViewModels/TopicViewModel.cs
@@ -20,17 +20,19 @@ public partial class TopicViewModel: ViewModelBase, IMessageSource
     private bool isExpanded;
 
     [ObservableProperty] public List<IMessageFormatter> formatters;
-    public string? FormatterName { get; set; }
+    [ObservableProperty] private string? formatterName;
+    [ObservableProperty] private string? keyFormatterName;
 
     public ObservableCollection<MessageViewModel> Messages { get; } = new();
 
     public ITreeNode.NodeType Type => ITreeNode.NodeType.TOPIC;
 
-    public TopicViewModel(Topic topic, string? formatterName)
+    public TopicViewModel(Topic topic, string? formatterName, string? keyFormatterName)
     {
         formatters = FormatterFactory.Instance.GetFormatters();
         this.topic = topic;
         FormatterName = formatterName;
+        KeyFormatterName = keyFormatterName;
         foreach (var partition in topic.Partitions)
         {
             var viewModel = new PartitionViewModel(this, partition);


### PR DESCRIPTION
This change improves how message formatters are selected and managed in KafkaLens.

Key improvements:
1. **Manual Override**: Users can now manually specify formatters for both the Key and the Value of a topic.
2. **Persistence**: Formatter selections are saved to `%LOCALAPPDATA%/KafkaLens/topic_settings.json` and persist across sessions. Settings are cluster-specific but can be applied globally.
3. **Number Formatter**: A new `NumberFormatter` was added to handle numeric Kafka keys (Int16, Int32, Int64).
4. **Configuration Tab**: The Browser view now includes a "Configuration" tab where topic settings can be managed.
5. **Robust Guessing**: The existing guessing logic for values was kept, and a new one for keys was added. When "Auto" is selected, the application guesses the best formatter and saves the result as the manual selection.
6. **UI/UX**: Partition views now reflect the configuration of their parent topics. Formatters can be updated on the fly, re-formatting already loaded messages.

---
*PR created automatically by Jules for task [17354055623752631801](https://jules.google.com/task/17354055623752631801) started by @fatichar*