### PR TITLE
⚡ Optimize file discovery and bounded async I/O in SavedMessagesConsumer

### DIFF
--- a/BenchmarkProj/Benchmark.cs
+++ b/BenchmarkProj/Benchmark.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using KafkaLens.Clients;
+using KafkaLens.Shared.Models;
+using KafkaLens.Core.Services;
+using Serilog;
+using System.Collections.Generic;
+
+class Program
+{
+    static async Task Main(string[] args)
+    {
+        Log.Logger = new LoggerConfiguration()
+            .WriteTo.Console()
+            .CreateLogger();
+
+        Console.WriteLine("Setting up benchmark...");
+        string clusterDir = Path.Combine(Path.GetTempPath(), "KafkaLensBenchmarkCluster");
+        if (Directory.Exists(clusterDir))
+        {
+            Directory.Delete(clusterDir, true);
+        }
+        Directory.CreateDirectory(clusterDir);
+
+        string topicName = "test-topic";
+        string topicDir = Path.Combine(clusterDir, topicName);
+        Directory.CreateDirectory(topicDir);
+
+        int numPartitions = 5;
+        int filesPerPartition = 2000;
+
+        long baseTime = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - 1000000;
+
+        for (int p = 0; p < numPartitions; p++)
+        {
+            string partitionDir = Path.Combine(topicDir, p.ToString());
+            Directory.CreateDirectory(partitionDir);
+
+            for (int i = 0; i < filesPerPartition; i++)
+            {
+                long offset = i;
+                long timestamp = baseTime + i * 10;
+                string file = Path.Combine(partitionDir, $"{offset}.klm");
+
+                var msg = new Message(timestamp, new Dictionary<string, byte[]>(), new byte[10], new byte[10])
+                {
+                    Partition = p,
+                    Offset = offset
+                };
+
+                using var fs = File.OpenWrite(file);
+                msg.Serialize(fs);
+            }
+        }
+
+        Console.WriteLine($"Created {numPartitions} partitions with {filesPerPartition} files each.");
+
+        var consumer = new SavedMessagesConsumerWrapper(clusterDir);
+
+        // Warmup
+        var options = new FetchOptions(new FetchPosition(PositionType.Offset, 0), 10);
+        var stream = new MessageStream();
+        await consumer.PublicGetMessagesAsync(topicName, options, stream, CancellationToken.None);
+
+        Console.WriteLine("Running benchmark for multi-partition GetMessagesAsync...");
+        var sw = Stopwatch.StartNew();
+        options = new FetchOptions(new FetchPosition(PositionType.Offset, 0), 5000);
+        stream = new MessageStream();
+        await consumer.PublicGetMessagesAsync(topicName, options, stream, CancellationToken.None);
+        sw.Stop();
+        Console.WriteLine($"Multi-partition took: {sw.ElapsedMilliseconds} ms");
+
+        Console.WriteLine("Running benchmark for single-partition (LoadMessagesForPartitionAsync) with Timestamp...");
+        sw.Restart();
+        options = new FetchOptions(new FetchPosition(PositionType.Timestamp, baseTime + 1000 * 10), 1000) { Direction = FetchDirection.Forward };
+        stream = new MessageStream();
+        await consumer.PublicGetMessagesAsync(topicName, 0, options, stream, CancellationToken.None);
+        sw.Stop();
+        Console.WriteLine($"Single-partition (Forward from Timestamp) took: {sw.ElapsedMilliseconds} ms");
+
+        sw.Restart();
+        options = new FetchOptions(new FetchPosition(PositionType.Timestamp, baseTime + 1500 * 10), 100) { Direction = FetchDirection.Backward };
+        stream = new MessageStream();
+        await consumer.PublicGetMessagesAsync(topicName, 0, options, stream, CancellationToken.None);
+        sw.Stop();
+        Console.WriteLine($"Single-partition (Backward from Timestamp) took: {sw.ElapsedMilliseconds} ms");
+
+        Directory.Delete(clusterDir, true);
+    }
+}
+
+public class SavedMessagesConsumerWrapper : SavedMessagesConsumer
+{
+    public SavedMessagesConsumerWrapper(string clusterDir) : base(clusterDir) { }
+
+    public Task PublicGetMessagesAsync(string topicName, FetchOptions options, MessageStream messages, CancellationToken cancellationToken)
+    {
+        return GetMessagesAsync(topicName, options, messages, cancellationToken);
+    }
+
+    public Task PublicGetMessagesAsync(string topicName, int partition, FetchOptions options, MessageStream messages, CancellationToken cancellationToken)
+    {
+        return GetMessagesAsync(topicName, partition, options, messages, cancellationToken);
+    }
+}

--- a/BenchmarkProj/Benchmark.csproj
+++ b/BenchmarkProj/Benchmark.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../LocalClient/LocalClient.csproj" />
+    <ProjectReference Include="../Shared/Shared.csproj" />
+    <ProjectReference Include="../Core/Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/LocalClient/SavedMessagesConsumer.cs
+++ b/LocalClient/SavedMessagesConsumer.cs
@@ -90,19 +90,19 @@ public class SavedMessagesConsumer(string clusterDir) : ConsumerBase
             CancellationToken = cancellationToken
         };
 
-        // Scan all partitions in parallel, and files within partitions in parallel
-        await Parallel.ForEachAsync(partitionDirs, parallelOptions, async (partitionDir, ct) =>
+        var allFiles = partitionDirs.SelectMany(partitionDir =>
         {
             var partition = int.Parse(Path.GetFileName(partitionDir));
             var messageFiles = Directory.EnumerateFiles(partitionDir, "*.klm");
             var textFiles = Directory.EnumerateFiles(partitionDir, "*.txt");
-            var allFiles = messageFiles.Concat(textFiles);
+            return messageFiles.Concat(textFiles).Select(file => (file, partition));
+        });
 
-            await Parallel.ForEachAsync(allFiles, parallelOptions, async (file, innerCt) =>
-            {
-                var timestamp = await GetMessageTimestampAsync(file);
-                allFilesWithTimestamp.Add((file, partition, timestamp));
-            });
+        // Scan all files in parallel
+        await Parallel.ForEachAsync(allFiles, parallelOptions, async (fileMeta, ct) =>
+        {
+            var timestamp = await GetMessageTimestampAsync(fileMeta.file);
+            allFilesWithTimestamp.Add((fileMeta.file, fileMeta.partition, timestamp));
         });
 
         if (cancellationToken.IsCancellationRequested) return;
@@ -216,39 +216,28 @@ public class SavedMessagesConsumer(string clusterDir) : ConsumerBase
         if (options.Start.Type == PositionType.Timestamp)
         {
             var messages = new List<(string file, long offset)>();
+
+            // To avoid sequential await bottleneck, we load timestamps for all potential files in parallel.
+            // Since we need to find an anchor based on timestamp, we can query timestamps using GetMessageTimestampAsync.
+            var fileTimestamps = new long[fileOffsets.Count];
+            var timestampParallelOptions = new ParallelOptions
+            {
+                MaxDegreeOfParallelism = 20,
+                CancellationToken = cancellationToken
+            };
+
+            await Parallel.ForEachAsync(Enumerable.Range(0, fileOffsets.Count), timestampParallelOptions, async (i, ct) =>
+            {
+                fileTimestamps[i] = await GetMessageTimestampAsync(fileOffsets[i].file);
+            });
+
             if (options.Direction == FetchDirection.Backward)
             {
-                // Backward from Timestamp
-                for (int i = fileOffsets.Count - 1; i >= 0; i--)
-                {
-                    if (cancellationToken.IsCancellationRequested) return;
-                    var fileOffset = fileOffsets[i];
-                    var message = await CreateMessageAsync(fileOffset.file);
-
-                    // We want messages BEFORE or AT the timestamp (depending on semantics)
-                    // Usually "Backward from T" means find first message >= T, then go back?
-                    // Or find messages <= T?
-                    // ConfluentConsumer implementation: Resolve T -> Offset O. Then O - Limit + 1.
-                    // So we find the first message with Timestamp >= T. Let's call it Anchor.
-                    // Then we take Anchor and (Limit-1) messages before it.
-
-                    // Actually, let's stick to ConfluentConsumer logic:
-                    // 1. Find the offset corresponding to Timestamp.
-                    // 2. Adjust offset backward.
-                    // 3. Fetch forward.
-
-                    // But here we are iterating.
-                    // Let's find the Anchor index first.
-                }
-
-                // Optimized approach:
                 // Find index of first message >= Timestamp.
                 int anchorIndex = -1;
                 for (int i = 0; i < fileOffsets.Count; i++)
                 {
-                    if (cancellationToken.IsCancellationRequested) return;
-                    var msg = await CreateMessageAsync(fileOffsets[i].file);
-                    if (msg.EpochMillis >= options.Start.Timestamp)
+                    if (fileTimestamps[i] >= options.Start.Timestamp)
                     {
                         anchorIndex = i;
                         break;
@@ -257,49 +246,20 @@ public class SavedMessagesConsumer(string clusterDir) : ConsumerBase
 
                 if (anchorIndex == -1)
                 {
-                    // All messages are older than timestamp? Or none exist?
-                    // If all older, anchor is effectively "End".
-                    // But if we want >= Timestamp, and none exist, then offset is HighWatermark.
-                    // If we go backward from HighWatermark, we get the last messages.
                     anchorIndex = fileOffsets.Count;
                 }
 
                 int startIndex = Math.Max(0, anchorIndex - options.Limit + 1);
-                // We want to fetch UP TO anchorIndex (inclusive)
-                // If anchorIndex is count (non-existent), we fetch up to end?
-                // If anchorIndex is 5. We want [?, 5]. Limit 3. -> [3, 4, 5].
-                // Start index = 5 - 3 + 1 = 3.
-                // Count = 3.
-
-                // If anchorIndex is fileOffsets.Count (none found >= T).
-                // ConfluentConsumer behavior: T -> Offset. If T > all, Offset = HighWatermark.
-                // Backward from HighWatermark: [High-Limit+1, High].
-                // So [Count-Limit+1, Count].
-
-                startIndex = Math.Max(0, anchorIndex - options.Limit + 1);
                 int count = Math.Min(options.Limit, anchorIndex - startIndex + 1);
                 filesToProcess = fileOffsets.Skip(startIndex).Take(count);
             }
             else
             {
-                // Forward (Existing Logic but simpler)
-                // Find first message >= Timestamp
-                // Take Limit.
-
-                // This linear scan is slow but consistent with existing code structure
-                // Optimization: Binary search if timestamps are monotonic?
-                // Saved messages are sorted by offset (filename). Timestamps usually correlate but not guaranteed.
-                // We'll stick to linear scan as existing code did.
-
-                // Actually existing code scanned and added to list.
-                foreach (var fileOffset in fileOffsets)
+                for (int i = 0; i < fileOffsets.Count; i++)
                 {
-                    if (cancellationToken.IsCancellationRequested) return;
-
-                    var message = await CreateMessageAsync(fileOffset.file);
-                    if (message.EpochMillis >= options.Start.Timestamp)
+                    if (fileTimestamps[i] >= options.Start.Timestamp)
                     {
-                        messages.Add(fileOffset);
+                        messages.Add(fileOffsets[i]);
                         if (messages.Count >= options.Limit)
                         {
                             break;


### PR DESCRIPTION
💡 **What:** Optimized the internal file scanning loops in `SavedMessagesConsumer` to use parallel structures effectively. I flattened nested loops and replaced linear `await` loops with parallel `await` operations.
🎯 **Why:** Deeply nested `Parallel.ForEachAsync` configurations caused massive task queue allocations and forced essentially sequential execution limits. In addition, single partition message fetches had `O(N)` linear await loops calling `await CreateMessageAsync` which significantly slowed down forward and backward offset/timestamp bound resolution.
📊 **Measured Improvement:**
Multi-partition multi-file fetching:
- Baseline: 273 ms
- Improvement: 194 ms
- Change: ~30% faster

Single-partition backward search (Timestamp to Bounds):
- Baseline: 111 ms
- Improvement: 56 ms
- Change: ~50% faster

---
*PR created automatically by Jules for task [3277089601096280488](https://jules.google.com/task/3277089601096280488) started by @fatichar*