### PR TITLE
Add Umami Analytics to documentation website

### DIFF
--- a/docs/download.html
+++ b/docs/download.html
@@ -9,6 +9,13 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+
+    <!-- Umami Analytics -->
+    <script
+      defer
+      src="https://analytics.greenfit.in/script.js"
+      data-website-id="338cb98a-f616-4b20-b1e3-52070be1aab9"
+    ></script>
 </head>
 <body>
     <div id="navbar-placeholder"></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,13 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"
         rel="stylesheet">
+
+    <!-- Umami Analytics -->
+    <script
+      defer
+      src="https://analytics.greenfit.in/script.js"
+      data-website-id="338cb98a-f616-4b20-b1e3-52070be1aab9"
+    ></script>
 </head>
 
 <body>

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -9,6 +9,13 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+
+    <!-- Umami Analytics -->
+    <script
+      defer
+      src="https://analytics.greenfit.in/script.js"
+      data-website-id="338cb98a-f616-4b20-b1e3-52070be1aab9"
+    ></script>
 </head>
 <body>
     <div id="navbar-placeholder"></div>


### PR DESCRIPTION
I have added the Umami Analytics tracking script to the following pages in the `docs` directory:
- `index.html`
- `download.html`
- `usage.html`

The script is inserted into the `<head>` section of each file as requested:
```html
<!-- Umami Analytics -->
<script
  defer
  src="https://analytics.greenfit.in/script.js"
  data-website-id="338cb98a-f616-4b20-b1e3-52070be1aab9"
></script>
```

I have verified the changes using a Playwright script that confirms the presence of the script tag on each page and generates screenshots for visual confirmation.

---
*PR created automatically by Jules for task [11772724419013712206](https://jules.google.com/task/11772724419013712206) started by @fatichar*