### PR TITLE
Website Updates: Analytics, UTM Tracking, and SEO Enhancement

### DIFF
--- a/docs/assets/analytics.js
+++ b/docs/assets/analytics.js
@@ -1,0 +1,110 @@
+(function() {
+    // UTM Parameters Handling
+    const UTM_PARAMS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'];
+
+    function captureUtmParams() {
+        const urlParams = new URLSearchParams(window.location.search);
+        let hasUtm = false;
+        const storedUtm = {};
+
+        UTM_PARAMS.forEach(param => {
+            if (urlParams.has(param)) {
+                storedUtm[param] = urlParams.get(param);
+                hasUtm = true;
+            }
+        });
+
+        if (hasUtm) {
+            localStorage.setItem('kafkale_utm', JSON.stringify(storedUtm));
+        }
+    }
+
+    function getStoredUtmParams() {
+        const stored = localStorage.getItem('kafkale_utm');
+        return stored ? JSON.parse(stored) : {};
+    }
+
+    function mergeParamsIntoUrl(targetUrl, sourceUrl = window.location.href) {
+        const targetObj = new URL(targetUrl, window.location.origin);
+        const sourceParams = new URL(sourceUrl).searchParams;
+        const storedUtm = getStoredUtmParams();
+
+        // 1. Apply stored UTM parameters
+        for (const [key, value] of Object.entries(storedUtm)) {
+            targetObj.searchParams.set(key, value);
+        }
+
+        // 2. Apply/Overwrite with active query parameters from current page
+        for (const [key, value] of sourceParams.entries()) {
+            targetObj.searchParams.set(key, value);
+        }
+
+        return targetObj.toString();
+    }
+
+    // Event Tracking
+    function trackEvent(name, data = {}) {
+        return new Promise((resolve) => {
+            if (window.umami && typeof window.umami.track === 'function') {
+                const utm = getStoredUtmParams();
+                const eventData = { ...utm, ...data };
+                window.umami.track(name, eventData);
+                // Give it a small buffer to ensure the request is sent
+                setTimeout(resolve, 300);
+            } else {
+                console.warn(`Umami not loaded. Event ${name} not tracked.`);
+                resolve();
+            }
+        });
+    }
+
+    // Global Click Interceptor
+    document.addEventListener('click', async function(e) {
+        const target = e.target.closest('a');
+        if (!target) return;
+
+        const href = target.getAttribute('href');
+        if (!href) return;
+
+        // Internal Download Links
+        const osMatch = href.match(/\/download\/(windows|macos|linux)/);
+        if (osMatch) {
+            e.preventDefault();
+            const os = osMatch[1];
+            const downloadUrl = getDownloadUrl(os);
+
+            if (downloadUrl) {
+                await trackEvent(`download_${os}`);
+                window.location.href = mergeParamsIntoUrl(downloadUrl);
+            }
+            return;
+        }
+
+        // GitHub Links
+        if (href.includes('github.com')) {
+            e.preventDefault();
+            const isRelease = href.includes('/releases');
+            await trackEvent(isRelease ? 'view_release_notes' : 'view_github');
+            window.open(href, target.getAttribute('target') || '_self');
+            return;
+        }
+
+        // Buy Me A Coffee
+        if (href.includes('buymeacoffee.com')) {
+            e.preventDefault();
+            await trackEvent('buy_me_a_coffee');
+            window.open(href, target.getAttribute('target') || '_self');
+            return;
+        }
+    });
+
+    // Initialize
+    captureUtmParams();
+
+    // Export to window
+    window.Analytics = {
+        trackEvent,
+        getStoredUtmParams,
+        mergeParamsIntoUrl
+    };
+})();

--- a/docs/assets/config.js
+++ b/docs/assets/config.js
@@ -1,0 +1,27 @@
+const KAFKALENS_CONFIG = {
+    github: {
+        owner: 'fatichar',
+        repo: 'KafkaLens',
+        version: 'v0.9.5',
+        assets: {
+            windows: 'KafkaLens-0.9.5-win-x64-installer.exe',
+            macos: 'KafkaLens-0.9.5-macos-arm64.zip',
+            linux: 'KafkaLens-0.9.5-linux-x64.zip'
+        }
+    },
+    umami: {
+        scriptUrl: 'https://analytics.greenfit.in/script.js',
+        websiteId: 'b9d3274a-0dbd-46d3-b1e9-762c04e02461'
+    }
+};
+
+function getDownloadUrl(os) {
+    const { owner, repo, version, assets } = KAFKALENS_CONFIG.github;
+    const asset = assets[os];
+    if (!asset) return null;
+    return `https://github.com/${owner}/${repo}/releases/download/${version}/${asset}`;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { KAFKALENS_CONFIG, getDownloadUrl };
+}

--- a/docs/assets/fragments.js
+++ b/docs/assets/fragments.js
@@ -1,11 +1,27 @@
 // Inject navbar, footer, and analytics
 async function loadFragments() {
     try {
+        // Load configuration
+        if (typeof KAFKALENS_CONFIG === 'undefined') {
+            const configScript = document.createElement('script');
+            configScript.src = '/assets/config.js';
+            document.head.appendChild(configScript);
+            await new Promise(resolve => configScript.onload = resolve);
+        }
+
+        // Load analytics logic
+        if (typeof Analytics === 'undefined') {
+            const analyticsLogicScript = document.createElement('script');
+            analyticsLogicScript.src = '/assets/analytics.js';
+            document.head.appendChild(analyticsLogicScript);
+            await new Promise(resolve => analyticsLogicScript.onload = resolve);
+        }
+
         // Inject Umami analytics script directly to head
         const analyticsScript = document.createElement('script');
         analyticsScript.defer = true;
-        analyticsScript.src = 'https://analytics.greenfit.in/script.js';
-        analyticsScript.setAttribute('data-website-id', 'b9d3274a-0dbd-46d3-b1e9-762c04e02461');
+        analyticsScript.src = KAFKALENS_CONFIG.umami.scriptUrl;
+        analyticsScript.setAttribute('data-website-id', KAFKALENS_CONFIG.umami.websiteId);
         document.head.appendChild(analyticsScript);
 
         // Load navbar

--- a/docs/download.html
+++ b/docs/download.html
@@ -5,6 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Download KafkaLens - Windows, Linux, macOS</title>
     <meta name="description" content="Download KafkaLens for Windows, Linux, and MacOS. Get the latest version of the ultimate desktop Kafka client.">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://kafkale.ns/download.html">
+    <meta property="og:title" content="Download KafkaLens - Windows, Linux, macOS">
+    <meta property="og:description" content="Get the latest version of KafkaLens for your operating system and start managing your clusters with ease.">
+    <meta property="og:image" content="https://kafkale.ns/assets/images/Main.png">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://kafkale.ns/download.html">
+    <meta property="twitter:title" content="Download KafkaLens - Windows, Linux, macOS">
+    <meta property="twitter:description" content="Get the latest version of KafkaLens for your operating system and start managing your clusters with ease.">
+    <meta property="twitter:image" content="https://kafkale.ns/assets/images/Main.png">
+
     <link rel="stylesheet" href="assets/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -23,21 +38,21 @@
 
         <section class="downloads">
             <div class="container">
-                <h2>Latest Stable Release (v0.9.5)</h2>
+                <h2>Latest Stable Release</h2>
                 <div class="download-grid">
-                    <a href="https://github.com/fatichar/KafkaLens/releases/download/v0.9.5/KafkaLens-0.9.5-win-x64-installer.exe" class="download-card">
+                    <a href="/download/windows" class="download-card">
                         <div class="download-icon">🪟</div>
                         <h3>Windows</h3>
                         <p>x64 Installer</p>
                         <span class="btn btn-primary">Download</span>
                     </a>
-                    <a href="https://github.com/fatichar/KafkaLens/releases/download/v0.9.5/KafkaLens-0.9.5-macos-arm64.zip" class="download-card">
+                    <a href="/download/macos" class="download-card">
                         <div class="download-icon">🍎</div>
                         <h3>macOS</h3>
                         <p>Apple Silicon</p>
                         <span class="btn btn-primary">Download</span>
                     </a>
-                    <a href="https://github.com/fatichar/KafkaLens/releases/download/v0.9.5/KafkaLens-0.9.5-linux-x64.zip" class="download-card">
+                    <a href="/download/linux" class="download-card">
                         <div class="download-icon">🐧</div>
                         <h3>Linux</h3>
                         <p>x64 Binary</p>

--- a/docs/download/linux/index.html
+++ b/docs/download/linux/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Downloading KafkaLens for Linux...</title>
+    <script src="../../assets/config.js"></script>
+    <script src="../../assets/analytics.js"></script>
+    <script>
+        (async function() {
+            try {
+                if (!window.umami) {
+                    const script = document.createElement('script');
+                    script.src = KAFKALENS_CONFIG.umami.scriptUrl;
+                    script.setAttribute('data-website-id', KAFKALENS_CONFIG.umami.websiteId);
+                    document.head.appendChild(script);
+                    await new Promise(resolve => script.onload = resolve);
+                }
+
+                const os = 'linux';
+                const downloadUrl = getDownloadUrl(os);
+                if (downloadUrl) {
+                    await Analytics.trackEvent(`download_${os}`);
+                    window.location.href = Analytics.mergeParamsIntoUrl(downloadUrl);
+                } else {
+                    window.location.href = '/download.html';
+                }
+            } catch (err) {
+                window.location.href = '/download.html';
+            }
+        })();
+    </script>
+</head>
+<body>
+    <p>Redirecting to download... If it doesn't start, <a href="/download.html">click here</a>.</p>
+</body>
+</html>

--- a/docs/download/linux/index.html
+++ b/docs/download/linux/index.html
@@ -12,8 +12,13 @@
                     const script = document.createElement('script');
                     script.src = KAFKALENS_CONFIG.umami.scriptUrl;
                     script.setAttribute('data-website-id', KAFKALENS_CONFIG.umami.websiteId);
+                    const analyticsLoadTimeoutMs = 1500;
                     document.head.appendChild(script);
-                    await new Promise(resolve => script.onload = resolve);
+                    await new Promise(resolve => {
+                        script.onload = resolve;
+                        script.onerror = resolve;
+                        setTimeout(resolve, analyticsLoadTimeoutMs);
+                    });
                 }
 
                 const os = 'linux';

--- a/docs/download/macos/index.html
+++ b/docs/download/macos/index.html
@@ -12,8 +12,13 @@
                     const script = document.createElement('script');
                     script.src = KAFKALENS_CONFIG.umami.scriptUrl;
                     script.setAttribute('data-website-id', KAFKALENS_CONFIG.umami.websiteId);
+                    const analyticsLoadTimeoutMs = 1500;
                     document.head.appendChild(script);
-                    await new Promise(resolve => script.onload = resolve);
+                    await new Promise(resolve => {
+                        script.onload = resolve;
+                        script.onerror = resolve;
+                        setTimeout(resolve, analyticsLoadTimeoutMs);
+                    });
                 }
 
                 const os = 'macos';

--- a/docs/download/macos/index.html
+++ b/docs/download/macos/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Downloading KafkaLens for macOS...</title>
+    <script src="../../assets/config.js"></script>
+    <script src="../../assets/analytics.js"></script>
+    <script>
+        (async function() {
+            try {
+                if (!window.umami) {
+                    const script = document.createElement('script');
+                    script.src = KAFKALENS_CONFIG.umami.scriptUrl;
+                    script.setAttribute('data-website-id', KAFKALENS_CONFIG.umami.websiteId);
+                    document.head.appendChild(script);
+                    await new Promise(resolve => script.onload = resolve);
+                }
+
+                const os = 'macos';
+                const downloadUrl = getDownloadUrl(os);
+                if (downloadUrl) {
+                    await Analytics.trackEvent(`download_${os}`);
+                    window.location.href = Analytics.mergeParamsIntoUrl(downloadUrl);
+                } else {
+                    window.location.href = '/download.html';
+                }
+            } catch (err) {
+                window.location.href = '/download.html';
+            }
+        })();
+    </script>
+</head>
+<body>
+    <p>Redirecting to download... If it doesn't start, <a href="/download.html">click here</a>.</p>
+</body>
+</html>

--- a/docs/download/windows/index.html
+++ b/docs/download/windows/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Downloading KafkaLens for Windows...</title>
+    <script src="../../assets/config.js"></script>
+    <script src="../../assets/analytics.js"></script>
+    <script>
+        (async function() {
+            try {
+                if (!window.umami) {
+                    const script = document.createElement('script');
+                    script.src = KAFKALENS_CONFIG.umami.scriptUrl;
+                    script.setAttribute('data-website-id', KAFKALENS_CONFIG.umami.websiteId);
+                    document.head.appendChild(script);
+                    await new Promise(resolve => script.onload = resolve);
+                }
+
+                const os = 'windows';
+                const downloadUrl = getDownloadUrl(os);
+                if (downloadUrl) {
+                    await Analytics.trackEvent(`download_${os}`);
+                    window.location.href = Analytics.mergeParamsIntoUrl(downloadUrl);
+                } else {
+                    window.location.href = '/download.html';
+                }
+            } catch (err) {
+                window.location.href = '/download.html';
+            }
+        })();
+    </script>
+</head>
+<body>
+    <p>Redirecting to download... If it doesn't start, <a href="/download.html">click here</a>.</p>
+</body>
+</html>

--- a/docs/download/windows/index.html
+++ b/docs/download/windows/index.html
@@ -12,8 +12,13 @@
                     const script = document.createElement('script');
                     script.src = KAFKALENS_CONFIG.umami.scriptUrl;
                     script.setAttribute('data-website-id', KAFKALENS_CONFIG.umami.websiteId);
+                    const analyticsLoadTimeoutMs = 1500;
                     document.head.appendChild(script);
-                    await new Promise(resolve => script.onload = resolve);
+                    await new Promise(resolve => {
+                        script.onload = resolve;
+                        script.onerror = resolve;
+                        setTimeout(resolve, analyticsLoadTimeoutMs);
+                    });
                 }
 
                 const os = 'windows';

--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,21 @@
     <title>KafkaLens - The Ultimate Desktop Kafka Client</title>
     <meta name="description"
         content="KafkaLens: The ultimate desktop Kafka client. High-performance, cross-platform desktop client that makes Kafka development feel effortless.">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://kafkale.ns/">
+    <meta property="og:title" content="KafkaLens - The Ultimate Desktop Kafka Client">
+    <meta property="og:description" content="High-performance, cross-platform desktop client that makes Kafka development feel effortless.">
+    <meta property="og:image" content="https://kafkale.ns/assets/images/Main.png">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://kafkale.ns/">
+    <meta property="twitter:title" content="KafkaLens - The Ultimate Desktop Kafka Client">
+    <meta property="twitter:description" content="High-performance, cross-platform desktop client that makes Kafka development feel effortless.">
+    <meta property="twitter:image" content="https://kafkale.ns/assets/images/Main.png">
+
     <link rel="stylesheet" href="assets/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -5,6 +5,21 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Usage Documentation - KafkaLens</title>
     <meta name="description" content="Master KafkaLens with our comprehensive usage guide. Learn how to manage clusters, browse messages, and use advanced features.">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://kafkale.ns/usage.html">
+    <meta property="og:title" content="Usage Documentation - KafkaLens">
+    <meta property="og:description" content="Master KafkaLens with our comprehensive usage guide. Learn how to manage clusters, browse messages, and use advanced features.">
+    <meta property="og:image" content="https://kafkale.ns/assets/images/Main.png">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://kafkale.ns/usage.html">
+    <meta property="twitter:title" content="Usage Documentation - KafkaLens">
+    <meta property="twitter:description" content="Master KafkaLens with our comprehensive usage guide. Learn how to manage clusters, browse messages, and use advanced features.">
+    <meta property="twitter:image" content="https://kafkale.ns/assets/images/Main.png">
+
     <link rel="stylesheet" href="assets/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
I have updated the KafkaLens website to prepare it for the company-wide launch. Key improvements include:

1.  **Centralized Configuration**: All GitHub release details (version, asset names) and Umami settings are now managed in a single file (`docs/assets/config.js`), making future updates effortless.
2.  **Robust Analytics**: Every download and key interaction (GitHub views, Release Notes, Buy Me A Coffee) is now tracked in Umami. I implemented a reliable tracking mechanism that prevents event loss during navigation.
3.  **Campaign Tracking (UTM)**: UTM parameters are now captured on first visit, persisted in `localStorage`, and automatically appended to all download links and redirects.
4.  **Download Endpoints**: Created clean redirect endpoints (`/download/windows`, etc.) that support both internal link tracking and direct external access, while preserving all active and stored query parameters.
5.  **SEO & Social**: Added OpenGraph and Twitter card metadata to ensure the site looks great when shared on social platforms.
6.  **Verification**: All changes were verified with automated Playwright scripts, confirming that UTM parameters are persisted and active query parameters are correctly merged during redirection.

### Umami Events Created:
- `download_windows`, `download_macos`, `download_linux`: Triggered when a user starts a download.
- `view_release_notes`: Triggered when visiting the GitHub releases page.
- `view_github`: Triggered for other GitHub repository links.
- `buy_me_a_coffee`: Triggered when clicking the support button.

### Download Flow:
1.  **Interaction**: User clicks a download link (e.g., `/download/windows`).
2.  **Tracking**: `analytics.js` intercepts the click, records the event in Umami, and waits briefly to ensure delivery.
3.  **Redirection**: The script merges any stored UTM parameters from `localStorage` with active query parameters from the URL and redirects the user to the corresponding GitHub Release asset.

### Manual Setup Required:
- **Umami**: Ensure the website ID `b9d3274a-0dbd-46d3-b1e9-762c04e02461` is configured in your Umami dashboard.
- **Updates**: To update the KafkaLens version or change asset names, simply edit `docs/assets/config.js`.

---
*PR created automatically by Jules for task [16962455238787124641](https://jules.google.com/task/16962455238787124641) started by @fatichar*