### PR TITLE
Add multi-topic message viewing with cross-field filtering

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,11 @@
   "permissions": {
     "allow": [
       "Bash(dotnet test:*)",
-      "Bash(dotnet build:*)"
+      "Bash(dotnet build:*)",
+      "Read(//usr/local/share/dotnet/sdk/**)",
+      "Read(//Users/pbhusari/.dotnet/**)",
+      "Read(//opt/homebrew/Cellar/**)",
+      "Bash(/opt/homebrew/bin/dotnet --list-sdks)"
     ]
   }
 }

--- a/AvaloniaApp/AvaloniaApp/Views/Browser.axaml
+++ b/AvaloniaApp/AvaloniaApp/Views/Browser.axaml
@@ -55,6 +55,8 @@
                               SelectionChanged="MessagesGrid_OnSelectionChanged"
                               ContextMenu="{StaticResource MessageGridContextMenu}">
                         <DataGrid.Columns>
+                            <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Topic"
+                                                Binding="{Binding Topic}" SortMemberPath="Topic" />
                             <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Partition"
                                                 Binding="{Binding Partition }" SortMemberPath="Partition" />
                             <DataGridTextColumn x:DataType="vm:MessageViewModel" Header="Offset" Binding="{Binding Offset}" SortMemberPath="Offset" />

--- a/AvaloniaApp/AvaloniaApp/Views/MessagesToolbar.axaml
+++ b/AvaloniaApp/AvaloniaApp/Views/MessagesToolbar.axaml
@@ -7,7 +7,7 @@
 		<TextBox Grid.Column="0" x:Name="FilterBox"
 		         VerticalContentAlignment="Center" VerticalAlignment="Center"
 		         Text="{Binding CurrentMessages.PositiveFilter}"
-		         PlaceholderText="Filter (Ctrl+F)"/>
+		         PlaceholderText="Filter body, key, headers, topic (Ctrl+F)"/>
 		<TextBlock Grid.Column="1" Text="F5 to refresh" VerticalAlignment="Center" Margin="8,0,0,0"
 		           FontSize="11" Foreground="Gray" IsVisible="{Binding !IsLoading}"/>
 		<Button Grid.Column="2" Content="?" VerticalAlignment="Center" Margin="5,0,0,0"
@@ -16,8 +16,11 @@
 				<Flyout>
 					<StackPanel Margin="10" MaxWidth="320">
 						<TextBlock FontWeight="Bold" Margin="0,0,0,8">Filter Syntax</TextBlock>
-						<TextBlock TextWrapping="Wrap" Margin="0,0,0,10">
+						<TextBlock TextWrapping="Wrap" Margin="0,0,0,6">
 							Combine search terms using boolean operators. Multiple words without an operator are treated as OR.
+						</TextBlock>
+						<TextBlock TextWrapping="Wrap" Margin="0,0,0,10" FontSize="11" Foreground="Gray">
+							A term matches if it is found in the message body, the key, any header name or value, or the topic name.
 						</TextBlock>
 						<Grid ColumnDefinitions="Auto, *" RowDefinitions="Auto, Auto, Auto, Auto, Auto">
 							<TextBlock Grid.Row="0" Grid.Column="0" FontFamily="Courier New" FontWeight="Bold" Margin="0,0,12,4">&amp;&amp;</TextBlock>

--- a/AvaloniaApp/AvaloniaApp/Views/TopicsPanel.axaml
+++ b/AvaloniaApp/AvaloniaApp/Views/TopicsPanel.axaml
@@ -1,12 +1,23 @@
-﻿<UserControl x:Class="AvaloniaApp.Views.TopicsPanel"
+<UserControl x:Class="AvaloniaApp.Views.TopicsPanel"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:KafkaLens.ViewModels;assembly=KafkaLens.ViewModels"
              xmlns:av="clr-namespace:Avalonia.Controls;assembly=Avalonia.Controls"
              x:DataType="vm:OpenedClusterViewModel">
-    <Grid RowDefinitions="Auto,*">
+    <Grid RowDefinitions="Auto,Auto,*">
         <TextBox Text="{Binding FilterText, UpdateSourceTrigger=PropertyChanged}" PlaceholderText="Filter topics..." Margin="5"/>
-        <TreeView Grid.Row="1" Name="TopicsTree" ItemsSource="{Binding Children}"
+        <Border Grid.Row="1" IsVisible="{Binding HasCheckedTopics}" Margin="5,0,5,5"
+                Padding="6,3" CornerRadius="3"
+                Background="{DynamicResource ThemeToolbarBackgroundBrush}"
+                BorderThickness="1" BorderBrush="{DynamicResource ThemeBorderBrush}">
+            <Grid ColumnDefinitions="*,Auto">
+                <TextBlock Text="{Binding CheckedTopicsSummary}" FontSize="11" VerticalAlignment="Center"/>
+                <Button Grid.Column="1" Content="Clear" FontSize="11" Padding="6,1"
+                        Command="{Binding ClearCheckedTopicsCommand}"
+                        ToolTip.Tip="Uncheck all topics and clear the viewer"/>
+            </Grid>
+        </Border>
+        <TreeView Grid.Row="2" Name="TopicsTree" ItemsSource="{Binding Children}"
                   SelectedItem="{Binding SelectedNode}">
             <TreeView.Styles>
                 <Style Selector="av|TreeViewItem" x:DataType="vm:ITreeNode">
@@ -16,7 +27,14 @@
             </TreeView.Styles>
             <TreeView.ItemTemplate>
                 <TreeDataTemplate x:DataType="vm:ITreeNode" ItemsSource="{Binding Children}">
-                    <TextBlock Text="{Binding Name}" Margin="0" FontSize="12"/>
+                    <StackPanel Orientation="Horizontal" Spacing="4">
+                        <CheckBox IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                  IsVisible="{Binding IsCheckable}"
+                                  MinWidth="0" MinHeight="0" Padding="0"
+                                  VerticalAlignment="Center"
+                                  ToolTip.Tip="Include this topic's messages in the viewer"/>
+                        <TextBlock Text="{Binding Name}" Margin="0" FontSize="12" VerticalAlignment="Center"/>
+                    </StackPanel>
                 </TreeDataTemplate>
             </TreeView.ItemTemplate>
         </TreeView>

--- a/Shared/Models/BrowserConfig.cs
+++ b/Shared/Models/BrowserConfig.cs
@@ -21,6 +21,8 @@ public class OpenedTabState
     public string? SelectedNodeType { get; set; }
     public string? SelectedTopicName { get; set; }
     public int? SelectedPartitionId { get; set; }
+    /// <summary>Topics checked for multi-topic viewing. Empty means single-node mode.</summary>
+    public List<string> CheckedTopicNames { get; set; } = new();
     public string? FetchPosition { get; set; }
     public int FetchCount { get; set; }
     public bool FetchBackward { get; set; }

--- a/Shared/Utils/ObservableRangeCollection.cs
+++ b/Shared/Utils/ObservableRangeCollection.cs
@@ -29,6 +29,30 @@ public class ObservableRangeCollection<T> : ObservableCollection<T>
         OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, list, startIndex));
     }
 
+    /// <summary>
+    /// Removes every item matching <paramref name="match"/>, raising a single Reset
+    /// notification instead of one event per removal.
+    /// </summary>
+    public int RemoveAll(Predicate<T> match)
+    {
+        if (match == null) throw new ArgumentNullException(nameof(match));
+
+        CheckReentrancy();
+
+        var kept = Items.Where(item => !match(item)).ToList();
+        var removedCount = Items.Count - kept.Count;
+        if (removedCount == 0) return 0;
+
+        Items.Clear();
+        foreach (var i in kept) Items.Add(i);
+
+        OnPropertyChanged(new PropertyChangedEventArgs("Count"));
+        OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+        OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+
+        return removedCount;
+    }
+
     public void ReplaceRange(IEnumerable<T> collection)
     {
         if (collection == null) throw new ArgumentNullException(nameof(collection));

--- a/ViewModels.Tests/MessagesViewModelTests.cs
+++ b/ViewModels.Tests/MessagesViewModelTests.cs
@@ -305,10 +305,159 @@ public class MessagesViewModelTests
         Assert.False(viewModel.UseObjectFilter);
     }
 
+    // The key deliberately shares no text with the filter terms used above, so these tests
+    // exercise body matching rather than the key matching added for cross-field search.
     private MessageViewModel CreateMockMessageViewModel(string decodedMessage = "test message")
     {
-        var message = new Message(1640995200000, new Dictionary<string, byte[]>(), 
-            Encoding.UTF8.GetBytes("test key"), Encoding.UTF8.GetBytes(decodedMessage));
+        var message = new Message(1640995200000, new Dictionary<string, byte[]>(),
+            Encoding.UTF8.GetBytes("msg-key"), Encoding.UTF8.GetBytes(decodedMessage));
         return new MessageViewModel(message, "Text", "Text");
     }
+
+    private static MessageViewModel CreateMessageViewModel(
+        string body,
+        string key = "msg-key",
+        string? topic = null,
+        Dictionary<string, byte[]>? headers = null)
+    {
+        var message = new Message(1640995200000, headers ?? new Dictionary<string, byte[]>(),
+            Encoding.UTF8.GetBytes(key), Encoding.UTF8.GetBytes(body));
+        var viewModel = new MessageViewModel(message, "Text", "Text");
+        if (topic != null) viewModel.Topic = topic;
+        return viewModel;
+    }
+
+    #region cross-field filtering
+
+    [Fact]
+    public void PositiveFilter_ShouldMatchOnKey()
+    {
+        var viewModel = new MessagesViewModel();
+        var matching = CreateMessageViewModel("body one", key: "customer-42");
+        var nonMatching = CreateMessageViewModel("body two", key: "order-7");
+        viewModel.Add(matching);
+        viewModel.Add(nonMatching);
+
+        viewModel.PositiveFilter = "customer";
+
+        Assert.Single(viewModel.Filtered);
+        Assert.Equal(matching, viewModel.Filtered.First());
+    }
+
+    [Fact]
+    public void PositiveFilter_ShouldMatchOnHeaderName()
+    {
+        var viewModel = new MessagesViewModel();
+        var matching = CreateMessageViewModel("body one",
+            headers: new Dictionary<string, byte[]> { ["trace-id"] = Encoding.UTF8.GetBytes("abc") });
+        var nonMatching = CreateMessageViewModel("body two");
+        viewModel.Add(matching);
+        viewModel.Add(nonMatching);
+
+        viewModel.PositiveFilter = "trace-id";
+
+        Assert.Single(viewModel.Filtered);
+        Assert.Equal(matching, viewModel.Filtered.First());
+    }
+
+    [Fact]
+    public void PositiveFilter_ShouldMatchOnHeaderValue()
+    {
+        var viewModel = new MessagesViewModel();
+        var matching = CreateMessageViewModel("body one",
+            headers: new Dictionary<string, byte[]> { ["source"] = Encoding.UTF8.GetBytes("billing-service") });
+        var nonMatching = CreateMessageViewModel("body two",
+            headers: new Dictionary<string, byte[]> { ["source"] = Encoding.UTF8.GetBytes("shipping-service") });
+        viewModel.Add(matching);
+        viewModel.Add(nonMatching);
+
+        viewModel.PositiveFilter = "billing";
+
+        Assert.Single(viewModel.Filtered);
+        Assert.Equal(matching, viewModel.Filtered.First());
+    }
+
+    [Fact]
+    public void PositiveFilter_ShouldMatchOnTopicName()
+    {
+        var viewModel = new MessagesViewModel();
+        var matching = CreateMessageViewModel("body one", topic: "orders");
+        var nonMatching = CreateMessageViewModel("body two", topic: "payments");
+        viewModel.Add(matching);
+        viewModel.Add(nonMatching);
+
+        viewModel.PositiveFilter = "orders";
+
+        Assert.Single(viewModel.Filtered);
+        Assert.Equal(matching, viewModel.Filtered.First());
+    }
+
+    [Fact]
+    public void NegativeFilter_ShouldExcludeOnHeaderValue()
+    {
+        var viewModel = new MessagesViewModel();
+        var kept = CreateMessageViewModel("body one",
+            headers: new Dictionary<string, byte[]> { ["level"] = Encoding.UTF8.GetBytes("info") });
+        var excluded = CreateMessageViewModel("body two",
+            headers: new Dictionary<string, byte[]> { ["level"] = Encoding.UTF8.GetBytes("debug") });
+        viewModel.Add(kept);
+        viewModel.Add(excluded);
+
+        viewModel.NegativeFilter = "debug";
+
+        Assert.Single(viewModel.Filtered);
+        Assert.Equal(kept, viewModel.Filtered.First());
+    }
+
+    #endregion
+
+    #region RemoveTopic
+
+    [Fact]
+    public void RemoveTopic_ShouldDropOnlyThatTopicsMessages()
+    {
+        var viewModel = new MessagesViewModel();
+        var orders = CreateMessageViewModel("body one", topic: "orders");
+        var payments = CreateMessageViewModel("body two", topic: "payments");
+        viewModel.Add(orders);
+        viewModel.Add(payments);
+
+        viewModel.RemoveTopic("orders");
+
+        Assert.Single(viewModel.Messages);
+        Assert.Equal(payments, viewModel.Messages.First());
+        Assert.Single(viewModel.Filtered);
+        Assert.Equal(payments, viewModel.Filtered.First());
+    }
+
+    [Fact]
+    public void RemoveTopic_WhenSelectionRemoved_ShouldClearCurrentMessage()
+    {
+        var viewModel = new MessagesViewModel();
+        var orders = CreateMessageViewModel("body one", topic: "orders");
+        viewModel.Add(orders);
+        viewModel.CurrentMessage = orders;
+
+        viewModel.RemoveTopic("orders");
+
+        Assert.Empty(viewModel.Messages);
+        Assert.Null(viewModel.CurrentMessage);
+    }
+
+    [Fact]
+    public void RemoveTopic_WhenSelectionBelongsToAnotherTopic_ShouldKeepSelection()
+    {
+        var viewModel = new MessagesViewModel();
+        var orders = CreateMessageViewModel("body one", topic: "orders");
+        var payments = CreateMessageViewModel("body two", topic: "payments");
+        viewModel.Add(orders);
+        viewModel.Add(payments);
+        viewModel.CurrentMessage = payments;
+
+        viewModel.RemoveTopic("orders");
+
+        Assert.Equal(payments, viewModel.CurrentMessage);
+    }
+
+    #endregion
 }

--- a/ViewModels.Tests/OpenedClusterViewModelBusinessLogicTests.cs
+++ b/ViewModels.Tests/OpenedClusterViewModelBusinessLogicTests.cs
@@ -759,7 +759,7 @@ public class OpenedClusterViewModelBusinessLogicTests
         // Add a message to CurrentMessages
         var msg = new Message(1640995200000, new Dictionary<string, byte[]>(),
             Encoding.UTF8.GetBytes("key"), Encoding.UTF8.GetBytes("value"));
-        var msgVm = new MessageViewModel(msg, "Text", "Text");
+        var msgVm = new MessageViewModel(msg, "Text", "Text") { Topic = "test-topic" };
         vm.CurrentMessages.Add(msgVm);
 
         // Set formatter to a valid non-Auto name
@@ -789,7 +789,7 @@ public class OpenedClusterViewModelBusinessLogicTests
         vm.SelectedNode = vm.Topics[0];
         var msg = new Message(1640995200000, new Dictionary<string, byte[]>(),
             new byte[] { 0, 0, 0, 1 }, Encoding.UTF8.GetBytes("{\"id\":1}"));
-        vm.CurrentMessages.Add(new MessageViewModel(msg, "Text", "Text"));
+        vm.CurrentMessages.Add(new MessageViewModel(msg, "Text", "Text") { Topic = "test-topic" });
 
         vm.Topics[0].FormatterName = "Unknown";
         vm.Topics[0].KeyFormatterName = "Unknown";
@@ -852,6 +852,161 @@ public class OpenedClusterViewModelBusinessLogicTests
         // Assert
         Assert.Single(vm.CurrentMessages.Messages);
         Assert.Equal("hello world", vm.CurrentMessages.Messages[0].DecodedMessage);
+    }
+
+    #endregion
+
+    #region Checked topics (multi-topic view)
+
+    private async Task<OpenedClusterViewModel> CreateViewModelWithTopicsAsync(
+        params string[] topicNames)
+    {
+        var vm = CreateViewModel();
+        var topics = topicNames
+            .Select(name => new Topic(name, new List<Partition> { new(0) }))
+            .ToList();
+        mockClient.GetTopicsAsync("c1").Returns(Task.FromResult<IList<Topic>>(topics));
+        await vm.LoadTopicsAsync();
+        vm.IsCurrent = true;
+
+        foreach (var topic in vm.Topics)
+        {
+            // Avoids the formatter-guessing path so the tests focus on fetch orchestration.
+            topic.FormatterName = "Text";
+            topic.KeyFormatterName = "Text";
+            mockClient.GetMessageStream("c1", topic.Name, Arg.Any<FetchOptions>(), Arg.Any<CancellationToken>())
+                .Returns(_ => new MessageStream());
+        }
+
+        return vm;
+    }
+
+    [AvaloniaFact]
+    public async Task CheckingTopic_ShouldFetchThatTopic()
+    {
+        var vm = await CreateViewModelWithTopicsAsync("topic-a", "topic-b");
+
+        vm.Topics[0].IsChecked = true;
+
+        Assert.True(vm.HasCheckedTopics);
+        Assert.Equal(1, vm.CheckedTopicCount);
+        mockClient.Received(1).GetMessageStream("c1", "topic-a", Arg.Any<FetchOptions>(), Arg.Any<CancellationToken>());
+        mockClient.DidNotReceive().GetMessageStream("c1", "topic-b", Arg.Any<FetchOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [AvaloniaFact]
+    public async Task CheckingSecondTopic_ShouldFetchItWithoutRefetchingTheFirst()
+    {
+        var vm = await CreateViewModelWithTopicsAsync("topic-a", "topic-b");
+
+        vm.Topics[0].IsChecked = true;
+        vm.Topics[1].IsChecked = true;
+
+        Assert.Equal(2, vm.CheckedTopicCount);
+        mockClient.Received(1).GetMessageStream("c1", "topic-a", Arg.Any<FetchOptions>(), Arg.Any<CancellationToken>());
+        mockClient.Received(1).GetMessageStream("c1", "topic-b", Arg.Any<FetchOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [AvaloniaFact]
+    public async Task CheckedTopics_ShouldEnableFetchOptionsWithoutTreeSelection()
+    {
+        var vm = await CreateViewModelWithTopicsAsync("topic-a");
+
+        Assert.False(vm.IsFetchOptionsEnabled);
+
+        vm.Topics[0].IsChecked = true;
+
+        Assert.True(vm.IsFetchOptionsEnabled);
+    }
+
+    [AvaloniaFact]
+    public async Task UncheckingTopic_ShouldRemoveOnlyThatTopicsMessages()
+    {
+        var vm = await CreateViewModelWithTopicsAsync("topic-a", "topic-b");
+        vm.Topics[0].IsChecked = true;
+        vm.Topics[1].IsChecked = true;
+
+        var msgA = new Message(1640995200000, new Dictionary<string, byte[]>(), null, []);
+        var msgB = new Message(1640995200001, new Dictionary<string, byte[]>(), null, []);
+        vm.CurrentMessages.Add(new MessageViewModel(msgA, "Text", "Text") { Topic = "topic-a" });
+        vm.CurrentMessages.Add(new MessageViewModel(msgB, "Text", "Text") { Topic = "topic-b" });
+
+        vm.Topics[0].IsChecked = false;
+
+        Assert.Equal(1, vm.CheckedTopicCount);
+        Assert.Single(vm.CurrentMessages.Messages);
+        Assert.Equal("topic-b", vm.CurrentMessages.Messages[0].Topic);
+    }
+
+    [AvaloniaFact]
+    public async Task ClearCheckedTopics_ShouldUncheckAllAndClearViewer()
+    {
+        var vm = await CreateViewModelWithTopicsAsync("topic-a", "topic-b");
+        vm.Topics[0].IsChecked = true;
+        vm.Topics[1].IsChecked = true;
+
+        var msg = new Message(1640995200000, new Dictionary<string, byte[]>(), null, []);
+        vm.CurrentMessages.Add(new MessageViewModel(msg, "Text", "Text") { Topic = "topic-a" });
+
+        vm.ClearCheckedTopicsCommand.Execute(null);
+
+        Assert.False(vm.HasCheckedTopics);
+        Assert.Empty(vm.CurrentMessages.Messages);
+    }
+
+    [AvaloniaFact]
+    public async Task SelectedNode_WhenTopicsChecked_ShouldNotRefetch()
+    {
+        var vm = await CreateViewModelWithTopicsAsync("topic-a", "topic-b");
+        vm.Topics[0].IsChecked = true;
+        mockClient.ClearReceivedCalls();
+
+        // Moving the tree selection in multi-topic mode retargets the config panel only.
+        vm.SelectedNode = vm.Topics[1];
+
+        mockClient.DidNotReceive().GetMessageStream(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<FetchOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [AvaloniaFact]
+    public async Task Refresh_WithCheckedTopics_ShouldRefetchEveryCheckedTopic()
+    {
+        var vm = await CreateViewModelWithTopicsAsync("topic-a", "topic-b");
+        vm.Topics[0].IsChecked = true;
+        vm.Topics[1].IsChecked = true;
+        mockClient.ClearReceivedCalls();
+
+        vm.RefreshCommand.Execute(null);
+
+        mockClient.Received(1).GetMessageStream("c1", "topic-a", Arg.Any<FetchOptions>(), Arg.Any<CancellationToken>());
+        mockClient.Received(1).GetMessageStream("c1", "topic-b", Arg.Any<FetchOptions>(), Arg.Any<CancellationToken>());
+    }
+
+    [AvaloniaFact]
+    public async Task FetchMessages_WithMultipleCheckedTopics_ShouldRequestFullCountPerTopic()
+    {
+        var vm = await CreateViewModelWithTopicsAsync("topic-a", "topic-b");
+        vm.FetchCount = 250;
+
+        vm.Topics[0].IsChecked = true;
+        vm.Topics[1].IsChecked = true;
+
+        mockClient.Received(1).GetMessageStream("c1", "topic-a",
+            Arg.Is<FetchOptions>(o => o.Limit == 250), Arg.Any<CancellationToken>());
+        mockClient.Received(1).GetMessageStream("c1", "topic-b",
+            Arg.Is<FetchOptions>(o => o.Limit == 250), Arg.Any<CancellationToken>());
+    }
+
+    [AvaloniaFact]
+    public async Task CapturedTabState_ShouldRoundTripCheckedTopics()
+    {
+        var vm = await CreateViewModelWithTopicsAsync("topic-a", "topic-b", "topic-c");
+        vm.Topics[0].IsChecked = true;
+        vm.Topics[2].IsChecked = true;
+
+        var state = vm.CaptureOpenedTabState();
+
+        Assert.Equal(new[] { "topic-a", "topic-c" }, state.CheckedTopicNames);
     }
 
     #endregion

--- a/ViewModels/ITreeNode.cs
+++ b/ViewModels/ITreeNode.cs
@@ -16,4 +16,14 @@ public interface ITreeNode
     bool IsExpanded { get; set; }
     bool IsSelected { get; set; }
     ObservableCollection<ITreeNode> Children { get; }
+
+    /// <summary>Whether this node can be included in a multi-node fetch. Topics only.</summary>
+    bool IsCheckable => false;
+
+    /// <summary>Included in the multi-topic fetch. Meaningful only when <see cref="IsCheckable"/>.</summary>
+    bool IsChecked
+    {
+        get => false;
+        set { }
+    }
 }

--- a/ViewModels/MessageViewModel.cs
+++ b/ViewModels/MessageViewModel.cs
@@ -4,12 +4,15 @@ using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using KafkaLens.Shared.Models;
 using KafkaLens.Formatting;
+using KafkaLens.ViewModels.Search;
 
 namespace KafkaLens.ViewModels;
 
-public sealed partial class MessageViewModel : ViewModelBase
+public sealed partial class MessageViewModel : ViewModelBase, ISearchTarget
 {
     public const int MAX_SUMMARY_LEN = 150;
+
+    private const StringComparison SearchComparison = StringComparison.OrdinalIgnoreCase;
 
     private readonly Message message;
 
@@ -105,6 +108,24 @@ public sealed partial class MessageViewModel : ViewModelBase
     }
 
     public string Topic { get; set; } = null!;
+
+    /// <summary>
+    /// Matches a search term against the topic name, key, headers and decoded body.
+    /// Cheap fields are checked before the body, which is typically the largest.
+    /// </summary>
+    public bool ContainsTerm(string term)
+    {
+        if (Topic?.Contains(term, SearchComparison) == true) return true;
+        if (Key?.Contains(term, SearchComparison) == true) return true;
+
+        foreach (var header in Headers)
+        {
+            if (header.Name.Contains(term, SearchComparison)) return true;
+            if (header.Value.Contains(term, SearchComparison)) return true;
+        }
+
+        return DecodedMessage?.Contains(term, SearchComparison) == true;
+    }
 
     private void UpdateText()
     {

--- a/ViewModels/MessagesViewModel.cs
+++ b/ViewModels/MessagesViewModel.cs
@@ -104,22 +104,22 @@ public sealed class MessagesViewModel: ViewModelBase
 
     private void ApplyFilter()
     {
-        var filtered = Messages.Where(m => FilterAccepts(m.DecodedMessage)).ToList();
+        var filtered = Messages.Where(FilterAccepts).ToList();
         Filtered.ReplaceRange(filtered);
     }
 
-    private bool FilterAccepts(string message)
+    private bool FilterAccepts(MessageViewModel message)
     {
         return NegativeFilterAccepts(message)
                && PositiveFilterAccepts(message);
     }
 
-    private bool PositiveFilterAccepts(string message)
+    private bool PositiveFilterAccepts(MessageViewModel message)
     {
         return positiveExpression.Matches(message);
     }
 
-    private bool NegativeFilterAccepts(string message)
+    private bool NegativeFilterAccepts(MessageViewModel message)
     {
         return !negativeExpression.Matches(message);
     }
@@ -134,7 +134,7 @@ public sealed class MessagesViewModel: ViewModelBase
     internal void Add(MessageViewModel message)
     {
         Messages.Add(message);
-        if (FilterAccepts(message.DecodedMessage))
+        if (FilterAccepts(message))
         {
             Filtered.Add(message);
         }
@@ -147,10 +147,29 @@ public sealed class MessagesViewModel: ViewModelBase
 
         Messages.AddRange(list);
 
-        var filteredList = list.Where(m => FilterAccepts(m.DecodedMessage)).ToList();
+        var filteredList = list.Where(FilterAccepts).ToList();
         if (filteredList.Count > 0)
         {
             Filtered.AddRange(filteredList);
         }
+    }
+
+    /// <summary>
+    /// Drops every message belonging to <paramref name="topicName"/>. Used when a topic is
+    /// unchecked so its rows leave the viewer without disturbing the other topics.
+    /// </summary>
+    internal void RemoveTopic(string topicName)
+    {
+        Predicate<MessageViewModel> belongsToTopic = m =>
+            string.Equals(m.Topic, topicName, StringComparison.Ordinal);
+
+        var selectionRemoved = currentMessage != null && belongsToTopic(currentMessage);
+
+        Messages.RemoveAll(belongsToTopic);
+        Filtered.RemoveAll(belongsToTopic);
+
+        // Cleared after removal: the CurrentMessage setter ignores null while the
+        // selection is still present in Filtered.
+        if (selectionRemoved) CurrentMessage = null;
     }
 }

--- a/ViewModels/OpenedClusterViewModel.Fetching.cs
+++ b/ViewModels/OpenedClusterViewModel.Fetching.cs
@@ -8,82 +8,239 @@ namespace KafkaLens.ViewModels;
 
 public partial class OpenedClusterViewModel
 {
-    private MessageStream? messages;
+    /// <summary>
+    /// One in-flight fetch. A tab runs one of these per checked topic, so each stream needs
+    /// its own formatter source and cancellation independent of the tree selection.
+    /// </summary>
+    private sealed class ActiveFetch
+    {
+        public required IMessageSource Source { get; init; }
+        public required string TopicName { get; init; }
+        public required int? PartitionId { get; init; }
+        public required MessageStream Stream { get; init; }
+        public required CancellationTokenSource Cts { get; init; }
+        public required int RequestedCount { get; init; }
+        public NotifyCollectionChangedEventHandler? MessagesChanged { get; set; }
+        public MessageStream.FinishedEventHandler? Finished { get; set; }
+
+        public string Description => PartitionId.HasValue
+            ? $"topic {TopicName}, partition {PartitionId.Value}"
+            : $"topic {TopicName}";
+
+        public bool Targets(string topicName, int? partitionId) =>
+            PartitionId == partitionId &&
+            string.Equals(TopicName, topicName, StringComparison.Ordinal);
+    }
+
     private readonly List<IMessageLoadListener> messageLoadListeners = new();
     private readonly List<MessageViewModel> pendingMessages = new();
-    private CancellationTokenSource? fetchCts;
-    private string? activeFetchDescription;
-    private int activeFetchRequestedCount;
 
-    private void OnStreamFinished()
-    {
-        Dispatcher.UIThread.InvokeAsync(() =>
-        {
-            IsLoading = false;
-            appLogService.LogInfo(
-                $"Fetched {messages?.Messages.Count ?? 0} of {activeFetchRequestedCount} messages from {activeFetchDescription}",
-                "Fetch");
-            messageLoadListeners.ForEach(l => l.MessageLoadingFinished());
-        });
-    }
+    /// <summary>Mutated only on the UI thread.</summary>
+    private readonly List<ActiveFetch> activeFetches = new();
 
     private void StopLoading()
     {
-        if (IsLoading && activeFetchDescription != null)
-            appLogService.LogInfo($"Cancelled fetch from {activeFetchDescription}", "Fetch");
-        fetchCts?.Cancel();
+        if (IsLoading && activeFetches.Count > 0)
+        {
+            appLogService.LogInfo(
+                $"Cancelled fetch from {DescribeTargets(activeFetches.Select(f => f.Description))}", "Fetch");
+        }
+
+        CancelAllFetches();
         IsLoading = false;
     }
 
-    private void FetchMessages()
+    /// <summary>
+    /// The topics/partitions the next fetch should read. Checked topics take priority; with
+    /// none checked this falls back to the single tree-selected node.
+    /// </summary>
+    private List<IMessageSource> GetFetchTargets()
     {
-        if (selectedNode == null) return;
-
-        fetchCts?.Cancel();
-        fetchCts = new CancellationTokenSource();
-
-        if (messages != null)
+        var checkedTopics = Topics.Where(t => t.IsChecked).ToList();
+        if (checkedTopics.Count > 0)
         {
-            messages.Messages.CollectionChanged -= OnMessagesChanged;
-            messages.Finished -= OnStreamFinished;
+            return checkedTopics.Cast<IMessageSource>().ToList();
         }
 
-        CurrentMessages.Clear();
-        IsLoading = true;
+        return selectedNode is IMessageSource source
+            ? new List<IMessageSource> { source }
+            : new List<IMessageSource>();
+    }
 
-        var fetchOptions = CreateFetchOptions();
-        activeFetchDescription = GetFetchDescription(selectedNode);
-        activeFetchRequestedCount = fetchOptions.Limit;
+    /// <summary>Clears the viewer and refetches every current target.</summary>
+    private void FetchMessages()
+    {
+        var targets = GetFetchTargets();
+        if (targets.Count == 0) return;
+
+        CancelAllFetches();
+        CurrentMessages.Clear();
+
         appLogService.LogInfo(
-            $"Fetching {fetchOptions.Limit} messages from {activeFetchDescription}",
+            $"Fetching {FetchCount} messages from {DescribeTargets(targets.Select(t => GetFetchDescription(t)))}",
             "Fetch");
         messageLoadListeners.ForEach(l => l.MessageLoadingStarted());
 
+        IsLoading = true;
+        foreach (var target in targets)
+        {
+            StartFetch(target);
+        }
+
+        UpdateLoadingState();
+    }
+
+    /// <summary>
+    /// Starts a fetch for a single source and appends to the viewer without clearing it, so
+    /// checking another topic adds to the existing rows instead of refetching everything.
+    /// </summary>
+    private void StartFetch(IMessageSource source)
+    {
+        var topicName = GetTopicName(source);
+        if (topicName == null) return;
+
+        var partitionId = source is PartitionViewModel partition ? partition.Id : (int?)null;
+        CancelFetch(topicName, partitionId);
+
+        // A fresh FetchOptions per target: Limit and Direction are mutable, so streams must
+        // not share one instance.
+        var fetchOptions = CreateFetchOptions();
+        var cts = new CancellationTokenSource();
+        MessageStream? stream;
+
         try
         {
-            messages = selectedNode switch
-            {
-                TopicViewModel topic => KafkaLensClient.GetMessageStream(
-                    cluster.Id, topic.Name, fetchOptions, fetchCts.Token),
-                PartitionViewModel partition => KafkaLensClient.GetMessageStream(
-                    cluster.Id, partition.TopicName, partition.Id, fetchOptions, fetchCts.Token),
-                _ => null
-            };
+            stream = partitionId.HasValue
+                ? KafkaLensClient.GetMessageStream(cluster.Id, topicName, partitionId.Value, fetchOptions, cts.Token)
+                : KafkaLensClient.GetMessageStream(cluster.Id, topicName, fetchOptions, cts.Token);
         }
         catch (Exception e)
         {
-            IsLoading = false;
             Log.Error(e, "Failed to fetch messages for {ClusterName}", Name);
-            appLogService.LogError($"Could not fetch messages from {activeFetchDescription}: {e.Message}", "Fetch");
+            appLogService.LogError($"Could not fetch messages from topic {topicName}: {e.Message}", "Fetch");
+            UpdateLoadingState();
             return;
         }
 
-        if (messages != null)
+        if (stream == null)
         {
-            messages.Messages.CollectionChanged += OnMessagesChanged;
-            messages.Finished += OnStreamFinished;
+            UpdateLoadingState();
+            return;
+        }
+
+        var fetch = new ActiveFetch
+        {
+            Source = source,
+            TopicName = topicName,
+            PartitionId = partitionId,
+            Stream = stream,
+            Cts = cts,
+            RequestedCount = fetchOptions.Limit
+        };
+        fetch.MessagesChanged = (_, e) => OnMessagesChanged(fetch, e);
+        fetch.Finished = () => OnStreamFinished(fetch);
+
+        activeFetches.Add(fetch);
+        IsLoading = true;
+
+        stream.Messages.CollectionChanged += fetch.MessagesChanged;
+        stream.Finished += fetch.Finished;
+
+        // A short stream can finish before the handler is attached, in which case Finished
+        // never fires. OnStreamFinished is idempotent, so completing here is safe.
+        if (!stream.HasMore) OnStreamFinished(fetch);
+    }
+
+    private void CancelFetch(string topicName, int? partitionId = null)
+    {
+        var existing = activeFetches.Where(f => f.Targets(topicName, partitionId)).ToList();
+        foreach (var fetch in existing)
+        {
+            EndFetch(fetch);
         }
     }
+
+    /// <summary>Cancels every in-flight fetch and drops messages that have not been shown yet.</summary>
+    private void CancelAllFetches()
+    {
+        foreach (var fetch in activeFetches.ToList())
+        {
+            EndFetch(fetch);
+        }
+
+        lock (pendingMessages)
+        {
+            pendingMessages.Clear();
+        }
+    }
+
+    private void EndFetch(ActiveFetch fetch)
+    {
+        if (fetch.MessagesChanged != null)
+            fetch.Stream.Messages.CollectionChanged -= fetch.MessagesChanged;
+        if (fetch.Finished != null)
+            fetch.Stream.Finished -= fetch.Finished;
+
+        activeFetches.Remove(fetch);
+
+        lock (pendingMessages)
+        {
+            pendingMessages.RemoveAll(m => string.Equals(m.Topic, fetch.TopicName, StringComparison.Ordinal));
+        }
+
+        // Not disposed: the background stream task still holds the token, and disposing it
+        // from under that task surfaces ObjectDisposedException inside the fetch pipeline.
+        fetch.Cts.Cancel();
+    }
+
+    private void OnStreamFinished(ActiveFetch fetch)
+    {
+        Dispatcher.UIThread.InvokeAsync(() =>
+        {
+            UpdateMessages();
+
+            if (fetch.MessagesChanged != null)
+                fetch.Stream.Messages.CollectionChanged -= fetch.MessagesChanged;
+            if (fetch.Finished != null)
+                fetch.Stream.Finished -= fetch.Finished;
+
+            if (activeFetches.Remove(fetch))
+            {
+                appLogService.LogInfo(
+                    $"Fetched {fetch.Stream.Messages.Count} of {fetch.RequestedCount} messages from {fetch.Description}",
+                    "Fetch");
+            }
+
+            UpdateLoadingState();
+        });
+    }
+
+    /// <summary>Loading stays true until every stream in the tab has finished.</summary>
+    private void UpdateLoadingState()
+    {
+        if (activeFetches.Count > 0) return;
+
+        IsLoading = false;
+        messageLoadListeners.ForEach(l => l.MessageLoadingFinished());
+    }
+
+    private static string? GetTopicName(IMessageSource source) => source switch
+    {
+        TopicViewModel topic => topic.Name,
+        PartitionViewModel partition => partition.TopicName,
+        _ => null
+    };
+
+    private string GetCurrentTopicName() =>
+        (selectedNode is IMessageSource source ? GetTopicName(source) : null)
+        ?? throw new InvalidOperationException("No topic or partition is selected");
+
+    /// <summary>
+    /// Loaded messages belonging to one topic. The viewer can hold several topics at once, so
+    /// per-topic operations such as formatter changes must not touch the other topics' rows.
+    /// </summary>
+    private IEnumerable<MessageViewModel> LoadedMessagesForTopic(string topicName) =>
+        CurrentMessages.Messages.Where(m => string.Equals(m.Topic, topicName, StringComparison.Ordinal));
 
     private static string GetFetchDescription(ITreeNode node) => node switch
     {
@@ -92,13 +249,23 @@ public partial class OpenedClusterViewModel
         _ => node.Name
     };
 
-    private void OnMessagesChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    private static string DescribeTargets(IEnumerable<string> descriptions)
     {
-        var node = (IMessageSource?)SelectedNode;
-        if (node == null) return;
+        var list = descriptions.ToList();
+        return list.Count switch
+        {
+            0 => "no topics",
+            1 => list[0],
+            <= 3 => string.Join(", ", list),
+            _ => $"{list.Count} topics"
+        };
+    }
 
+    private void OnMessagesChanged(ActiveFetch fetch, NotifyCollectionChangedEventArgs e)
+    {
+        var node = fetch.Source;
+        var topicName = fetch.TopicName;
         bool settingsChanged = false;
-        var topicName = GetCurrentTopicName();
 
         if (formatterService.IsUnknownFormatter(node.FormatterName))
         {
@@ -151,13 +318,6 @@ public partial class OpenedClusterViewModel
         }
     }
 
-    private string GetCurrentTopicName() => selectedNode switch
-    {
-        TopicViewModel topic => topic.Name,
-        PartitionViewModel partition => partition.TopicName,
-        _ => throw new InvalidOperationException()
-    };
-
     public void UpdateMessages()
     {
         lock (pendingMessages)
@@ -168,9 +328,6 @@ public partial class OpenedClusterViewModel
                 pendingMessages.Clear();
             }
         }
-
-        if (!messages?.HasMore ?? false)
-            IsLoading = false;
     }
 
     internal FetchOptions CreateFetchOptions()

--- a/ViewModels/OpenedClusterViewModel.Formatters.cs
+++ b/ViewModels/OpenedClusterViewModel.Formatters.cs
@@ -9,9 +9,10 @@ public partial class OpenedClusterViewModel
     {
         if (SelectedNode is not IMessageSource node) return Task.CompletedTask;
 
-        TryGuessUnknownFormattersFromLoadedMessages(node);
-
         var topicName = GetCurrentTopicName();
+
+        TryGuessUnknownFormattersFromLoadedMessages(node, topicName);
+
         var settings = new TopicSettings
         {
             KeyFormatter = formatterService.ToKnownFormatterOrNull(node.KeyFormatterName),
@@ -19,7 +20,7 @@ public partial class OpenedClusterViewModel
         };
         topicSettingsService.SetSettings(cluster.Id, topicName, settings, ApplyToAllClusters);
 
-        foreach (var msg in CurrentMessages.Messages)
+        foreach (var msg in LoadedMessagesForTopic(topicName))
         {
             if (formatterService.CanApplyFormatterToLoadedMessages(settings.ValueFormatter, ValueFormatterNames))
                 msg.FormatterName = settings.ValueFormatter!;
@@ -30,12 +31,10 @@ public partial class OpenedClusterViewModel
         return Task.CompletedTask;
     }
 
-    private void TryGuessUnknownFormattersFromLoadedMessages(IMessageSource node)
+    private void TryGuessUnknownFormattersFromLoadedMessages(IMessageSource node, string topicName)
     {
-        if (CurrentMessages.Messages.Count == 0) return;
-
-        var firstMessage = CurrentMessages.Messages[0].Message;
-        var topicName = GetCurrentTopicName();
+        var firstMessage = LoadedMessagesForTopic(topicName).FirstOrDefault()?.Message;
+        if (firstMessage == null) return;
 
         if (formatterService.IsUnknownFormatter(node.FormatterName))
         {
@@ -57,9 +56,15 @@ public partial class OpenedClusterViewModel
 
     private void GuessFormatterForSelectedNode(bool isKeyFormatter)
     {
-        if (SelectedNode is not IMessageSource node || CurrentMessages.Messages.Count == 0) return;
+        if (SelectedNode is not IMessageSource node) return;
 
-        var firstMessage = CurrentMessages.Messages[0].Message;
+        var topicName = GetTopicName(node);
+        if (topicName == null) return;
+
+        var topicMessages = LoadedMessagesForTopic(topicName).ToList();
+        if (topicMessages.Count == 0) return;
+
+        var firstMessage = topicMessages[0].Message;
 
         if (isKeyFormatter)
         {
@@ -67,7 +72,7 @@ public partial class OpenedClusterViewModel
             if (string.IsNullOrWhiteSpace(keyFormatter)) return;
 
             node.KeyFormatterName = keyFormatter;
-            foreach (var msg in CurrentMessages.Messages)
+            foreach (var msg in topicMessages)
                 msg.KeyFormatterName = keyFormatter;
             return;
         }
@@ -75,7 +80,7 @@ public partial class OpenedClusterViewModel
         var valueFormatter = formatterService.GuessValueFormatter(firstMessage, ValueFormatterNames)?.Name
             ?? formatterService.GetDefaultFormatterName();
         node.FormatterName = valueFormatter;
-        foreach (var msg in CurrentMessages.Messages)
+        foreach (var msg in topicMessages)
             msg.FormatterName = valueFormatter;
     }
 }

--- a/ViewModels/OpenedClusterViewModel.Session.cs
+++ b/ViewModels/OpenedClusterViewModel.Session.cs
@@ -34,6 +34,7 @@ public partial class OpenedClusterViewModel
             SelectedNodeType = selectedNodeType,
             SelectedTopicName = selectedTopicName,
             SelectedPartitionId = selectedPartitionId,
+            CheckedTopicNames = Topics.Where(t => t.IsChecked).Select(t => t.Name).ToList(),
             FetchPosition = FetchPosition,
             FetchCount = FetchCount,
             FetchBackward = FetchBackward,
@@ -68,6 +69,10 @@ public partial class OpenedClusterViewModel
         if (state == null) return;
 
         pendingRestoreState = null;
+
+        // Restored before the selection so the SelectedNode setter sees multi-topic mode and
+        // leaves both the fetch positions and the viewer alone.
+        RestoreCheckedTopics(state.CheckedTopicNames);
 
         ITreeNode? targetNode = null;
         if (!string.IsNullOrWhiteSpace(state.SelectedTopicName))
@@ -116,12 +121,37 @@ public partial class OpenedClusterViewModel
                 UpdateStartTimeText();
         }
 
+        if (HasCheckedTopics) UseTopicFetchPositions();
+
         if (!string.IsNullOrWhiteSpace(state.FetchPosition) && FetchPositions.Contains(state.FetchPosition))
             FetchPosition = state.FetchPosition;
 
         if (IsFetchBackwardEnabled) FetchBackward = state.FetchBackward;
 
-        if (IsCurrent && targetNode is { Type: ITreeNode.NodeType.Topic or ITreeNode.NodeType.Partition })
+        if (IsCurrent &&
+            (HasCheckedTopics || targetNode is { Type: ITreeNode.NodeType.Topic or ITreeNode.NodeType.Partition }))
             FetchMessages();
+    }
+
+    private void RestoreCheckedTopics(List<string>? checkedTopicNames)
+    {
+        if (checkedTopicNames == null || checkedTopicNames.Count == 0) return;
+
+        var names = checkedTopicNames.ToHashSet(StringComparer.Ordinal);
+
+        // Suppressed so restoring N topics does not kick off N separate fetches; the single
+        // FetchMessages() at the end of the restore covers them all.
+        suppressCheckedTopicFetch = true;
+        try
+        {
+            foreach (var topic in Topics.Where(t => names.Contains(t.Name)))
+            {
+                topic.IsChecked = true;
+            }
+        }
+        finally
+        {
+            suppressCheckedTopicFetch = false;
+        }
     }
 }

--- a/ViewModels/OpenedClusterViewModel.Topics.cs
+++ b/ViewModels/OpenedClusterViewModel.Topics.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Avalonia.Threading;
 using KafkaLens.Shared;
 using KafkaLens.Shared.Models;
@@ -9,10 +10,18 @@ namespace KafkaLens.ViewModels;
 public partial class OpenedClusterViewModel
 {
     private bool isSyncingTopics;
+    private bool suppressCheckedTopicFetch;
 
     [ObservableProperty] private string filterText = "";
 
     partial void OnFilterTextChanged(string value) => FilterTopics();
+
+    public int CheckedTopicCount => Topics.Count(t => t.IsChecked);
+    public bool HasCheckedTopics => Topics.Any(t => t.IsChecked);
+
+    public string CheckedTopicsSummary => CheckedTopicCount == 1
+        ? "1 topic selected"
+        : $"{CheckedTopicCount} topics selected";
 
     internal async Task LoadTopicsAsync()
     {
@@ -27,15 +36,23 @@ public partial class OpenedClusterViewModel
                 return;
             }
 
+            foreach (var existing in Topics)
+            {
+                existing.PropertyChanged -= OnTopicPropertyChanged;
+            }
             Topics.Clear();
+
             foreach (var topic in cluster.Topics)
             {
                 var settings = topicSettingsService.GetSettings(cluster.Id, topic.Name);
                 var valueFormatter = formatterService.NormalizeFormatterName(settings.ValueFormatter, ValueFormatterNames);
                 var keyFormatter = formatterService.NormalizeFormatterName(settings.KeyFormatter, KeyFormatterNames);
-                Topics.Add(new TopicViewModel(topic, valueFormatter, keyFormatter));
+                var viewModel = new TopicViewModel(topic, valueFormatter, keyFormatter);
+                viewModel.PropertyChanged += OnTopicPropertyChanged;
+                Topics.Add(viewModel);
             }
 
+            NotifyCheckedTopicsChanged();
             FilterTopics();
             RestorePendingSessionState();
             appLogService.LogInfo($"Loaded {Topics.Count} topics for {Name}", "Topics");
@@ -61,5 +78,87 @@ public partial class OpenedClusterViewModel
                 Children.Add(topic);
             }
         }
+    }
+
+    private void OnTopicPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(TopicViewModel.IsChecked)) return;
+        if (sender is not TopicViewModel topic) return;
+
+        OnTopicCheckedChanged(topic);
+    }
+
+    /// <summary>
+    /// Checking a topic fetches just that topic and appends to the viewer; unchecking cancels
+    /// its fetch and drops its rows. Only the transition into multi-topic mode clears the
+    /// viewer, because the rows present then belong to the single selected node.
+    /// </summary>
+    private void OnTopicCheckedChanged(TopicViewModel topic)
+    {
+        NotifyCheckedTopicsChanged();
+
+        if (suppressCheckedTopicFetch) return;
+
+        if (topic.IsChecked)
+        {
+            if (CheckedTopicCount == 1)
+            {
+                CancelAllFetches();
+                CurrentMessages.Clear();
+                UseTopicFetchPositions();
+            }
+
+            if (IsCurrent) StartFetch(topic);
+        }
+        else
+        {
+            CancelFetch(topic.Name);
+            CurrentMessages.RemoveTopic(topic.Name);
+            UpdateLoadingState();
+        }
+    }
+
+    /// <summary>
+    /// A multi-topic fetch cannot use partition-only positions such as Offset.
+    /// </summary>
+    private void UseTopicFetchPositions()
+    {
+        FetchPositions = FetchPositionsForTopic;
+        if (FetchPosition == null || !FetchPositionsForTopic.Contains(FetchPosition))
+        {
+            FetchPosition = FetchPositionsForTopic[0];
+        }
+    }
+
+    internal void ClearCheckedTopics()
+    {
+        var checkedTopics = Topics.Where(t => t.IsChecked).ToList();
+        if (checkedTopics.Count == 0) return;
+
+        suppressCheckedTopicFetch = true;
+        try
+        {
+            foreach (var topic in checkedTopics)
+            {
+                topic.IsChecked = false;
+            }
+        }
+        finally
+        {
+            suppressCheckedTopicFetch = false;
+        }
+
+        CancelAllFetches();
+        CurrentMessages.Clear();
+        NotifyCheckedTopicsChanged();
+        UpdateLoadingState();
+    }
+
+    private void NotifyCheckedTopicsChanged()
+    {
+        OnPropertyChanged(nameof(CheckedTopicCount));
+        OnPropertyChanged(nameof(HasCheckedTopics));
+        OnPropertyChanged(nameof(CheckedTopicsSummary));
+        OnPropertyChanged(nameof(IsFetchOptionsEnabled));
     }
 }

--- a/ViewModels/OpenedClusterViewModel.cs
+++ b/ViewModels/OpenedClusterViewModel.cs
@@ -93,7 +93,8 @@ public partial class OpenedClusterViewModel : ViewModelBase, ITreeNode
     } = ITreeNode.NodeType.None;
 
     public bool IsFetchOptionsEnabled => SelectedNodeType == ITreeNode.NodeType.Topic ||
-                                         SelectedNodeType == ITreeNode.NodeType.Partition;
+                                         SelectedNodeType == ITreeNode.NodeType.Partition ||
+                                         HasCheckedTopics;
     public bool IsFetchBackwardEnabled => FetchPosition != "Start" && FetchPosition != "End";
     public int[] FetchCounts => settingsService.GetBrowserConfig().FetchCounts.ToArray();
 
@@ -117,6 +118,7 @@ public partial class OpenedClusterViewModel : ViewModelBase, ITreeNode
 
     public RelayCommand ToggleFetchCommand { get; }
     public RelayCommand RefreshCommand { get; }
+    public RelayCommand ClearCheckedTopicsCommand { get; }
     public RelayCommand GuessValueFormatterCommand { get; }
     public RelayCommand GuessKeyFormatterCommand { get; }
     public RelayCommand OpenFormatterPreferencesCommand { get; }
@@ -187,6 +189,7 @@ public partial class OpenedClusterViewModel : ViewModelBase, ITreeNode
             if (IsLoading) StopLoading();
             FetchMessages();
         });
+        ClearCheckedTopicsCommand = new RelayCommand(ClearCheckedTopics);
         GuessValueFormatterCommand = new RelayCommand(() => GuessFormatterForSelectedNode(isKeyFormatter: false));
         GuessKeyFormatterCommand = new RelayCommand(() => GuessFormatterForSelectedNode(isKeyFormatter: true));
         OpenFormatterPreferencesCommand = new RelayCommand(() => MainViewModel.ShowFormatterPreferences());
@@ -324,7 +327,7 @@ public partial class OpenedClusterViewModel : ViewModelBase, ITreeNode
                 SelectedNodeType = selectedNode?.Type ?? ITreeNode.NodeType.None;
                 var logicalNodeChanged = !AreSameLogicalNode(previousNode, selectedNode);
 
-                if (logicalNodeChanged)
+                if (logicalNodeChanged && !HasCheckedTopics)
                 {
                     var newFetchPositions = SelectedNodeType == ITreeNode.NodeType.Partition
                         ? FetchPositionsForPartition
@@ -339,7 +342,9 @@ public partial class OpenedClusterViewModel : ViewModelBase, ITreeNode
 
                 if (selectedNode is { Type: ITreeNode.NodeType.Partition } or { Type: ITreeNode.NodeType.Topic })
                 {
-                    if (IsCurrent && logicalNodeChanged && !suppressFetchOnSelectionChange)
+                    // In multi-topic mode the checkboxes own the viewer, so moving the tree
+                    // selection only retargets the config panel.
+                    if (IsCurrent && logicalNodeChanged && !suppressFetchOnSelectionChange && !HasCheckedTopics)
                         FetchMessages();
                 }
             }

--- a/ViewModels/Search/Expressions.cs
+++ b/ViewModels/Search/Expressions.cs
@@ -2,42 +2,42 @@ namespace KafkaLens.ViewModels.Search;
 
 public class TermExpression(string term) : IFilterExpression
 {
-    public bool Matches(string text)
+    public bool Matches(ISearchTarget target)
     {
-        return text.Contains(term, StringComparison.OrdinalIgnoreCase);
+        return target.ContainsTerm(term);
     }
 }
 
 public class AndExpression(IFilterExpression left, IFilterExpression right) : IFilterExpression
 {
-    public bool Matches(string text)
+    public bool Matches(ISearchTarget target)
     {
-        return left.Matches(text) && right.Matches(text);
+        return left.Matches(target) && right.Matches(target);
     }
 }
 
 public class OrExpression(IFilterExpression left, IFilterExpression right) : IFilterExpression
 {
-    public bool Matches(string text)
+    public bool Matches(ISearchTarget target)
     {
-        return left.Matches(text) || right.Matches(text);
+        return left.Matches(target) || right.Matches(target);
     }
 }
 
 public class NotExpression(IFilterExpression expression) : IFilterExpression
 {
-    public bool Matches(string text)
+    public bool Matches(ISearchTarget target)
     {
-        return !expression.Matches(text);
+        return !expression.Matches(target);
     }
 }
 
 public class AllMatchExpression : IFilterExpression
 {
-    public bool Matches(string text) => true;
+    public bool Matches(ISearchTarget target) => true;
 }
 
 public class NoneMatchExpression : IFilterExpression
 {
-    public bool Matches(string text) => false;
+    public bool Matches(ISearchTarget target) => false;
 }

--- a/ViewModels/Search/IFilterExpression.cs
+++ b/ViewModels/Search/IFilterExpression.cs
@@ -2,5 +2,8 @@ namespace KafkaLens.ViewModels.Search;
 
 public interface IFilterExpression
 {
-    bool Matches(string text);
+    bool Matches(ISearchTarget target);
+
+    /// <summary>Convenience overload for matching against plain text.</summary>
+    bool Matches(string text) => Matches(new TextSearchTarget(text));
 }

--- a/ViewModels/Search/ISearchTarget.cs
+++ b/ViewModels/Search/ISearchTarget.cs
@@ -1,0 +1,18 @@
+namespace KafkaLens.ViewModels.Search;
+
+/// <summary>
+/// A value that a filter expression can be evaluated against. Implementers decide which
+/// fields a search term is allowed to match, so a filter can span body, key, headers and
+/// topic without the expression tree knowing about message structure.
+/// </summary>
+public interface ISearchTarget
+{
+    /// <summary>True when any searchable field contains <paramref name="term"/>, ignoring case.</summary>
+    bool ContainsTerm(string term);
+}
+
+/// <summary>Searches a single string. Used where a filter is applied to plain text.</summary>
+public sealed class TextSearchTarget(string text) : ISearchTarget
+{
+    public bool ContainsTerm(string term) => text.Contains(term, StringComparison.OrdinalIgnoreCase);
+}

--- a/ViewModels/TopicViewModel.cs
+++ b/ViewModels/TopicViewModel.cs
@@ -13,11 +13,14 @@ public partial class TopicViewModel: ViewModelBase, IMessageSource
 
     public string Name => topic.Name;
     public bool IsExpandable => true;
+    public bool IsCheckable => true;
 
     [ObservableProperty]
     private bool isSelected;
     [ObservableProperty]
     private bool isExpanded;
+    [ObservableProperty]
+    private bool isChecked;
 
     [ObservableProperty] private List<IMessageFormatter> formatters;
     [ObservableProperty] private string? formatterName;


### PR DESCRIPTION
## Summary

Adds the ability to view messages from several topics at once, with a Topic column to
attribute each row, and widens the message filter to search keys, headers and topic
names rather than only the message body.

Previously a tab could fetch from exactly one node: `FetchMessages()` held a single
`MessageStream` and derived the topic name and formatters from `SelectedNode`. Comparing
traffic across topics meant opening a tab per topic and filtering each one separately.

## What's new

**Multi-topic selection.** Topics in the navigator tree are now checkable. Checked topics
fetch concurrently into a single viewer. Checkboxes appear on topics only — partitions
keep their existing click-to-select behaviour.

**Topic column.** Always visible in the message grid and sortable, so merged rows stay
attributable and can be grouped by topic.

**Cross-field filtering.** A filter term now matches against the message body, the key,
any header name or value, and the topic name. Boolean syntax (`&&`, `||`, `!`, `( )`,
quoted phrases) works across all fields, and `!term` correctly means "no field contains
term".

## Behaviour details

- **Selection and checking are separate concerns.** Checked topics own the viewer; moving
  the tree selection only retargets the Configuration tab and formatter panel. With
  nothing checked, the existing single-node click-to-fetch behaviour is unchanged, so
  current workflows are unaffected.
- **Fetch Count is per topic.** Each checked topic fetches the full count, consistent with
  the existing per-node meaning. Checking N topics loads N x FetchCount rows.
- **Checking is incremental.** Checking a topic fetches just that topic and appends;
  unchecking cancels its stream and drops only its rows, leaving other topics untouched.
  Only the transition into multi-topic mode clears the viewer, because the rows present at
  that point belong to the single selected node. F5 / Fetch still refetches everything.
- Rows arrive interleaved in stream order; sort by Timestamp or Topic to group them.
- Multi-topic mode uses topic-level fetch positions, excluding the partition-only Offset
  position.
- The checked set is persisted per tab and restored on startup as a single fetch.

## Implementation notes

`OpenedClusterViewModel.Fetching.cs` replaces the single stream and `CancellationTokenSource`
with a list of `ActiveFetch` contexts, each owning its stream, cancellation and formatter
source. `OnMessagesChanged` now closes over its own context instead of reading
`SelectedNode`. `IsLoading` clears only once every stream in the tab has finished.

`IFilterExpression.Matches` takes an `ISearchTarget` instead of a string, and
`MessageViewModel` implements it directly — no concatenated search string, so there is no
extra per-message allocation on large topics. A default interface method retains
`Matches(string)` for text callers. This also leaves room for scoped queries such as
`key:` or `header:` later.

**No Core or client changes.** `ConfluentConsumer` already pools consumers
(`ConsumerPool`, max 10 leases, `SemaphoreSlim`), so concurrent fetches against one cluster
were already supported. Checking many topics queues on that pool rather than failing.

## Fixes included

- **Formatter bleed across topics.** "Save topic settings" and "Guess formatter" applied
  the selected topic's formatter to *every* loaded message. Harmless with one topic in the
  grid, wrong once rows span topics — now scoped to the owning topic.
- **Potentially stuck loading indicator.** A stream finishing before its handler was
  attached never fired `Finished`, leaving `IsLoading` true. One stream made this rare; N
  streams make it N times likelier. Completion is now idempotent and triggered directly
  when the stream is already done.

## Testing

`dotnet build KafkaLens.slnx -c Release` and `dotnet test KafkaLens.slnx -c Release` both
pass. New tests cover the checked-topic flow (incremental fetch, no refetch on selection
change, per-topic limit, clear, session round-trip), cross-field filter matching on key,
header name, header value and topic, and per-topic message removal.

Two existing fixtures were adjusted rather than reinterpreted: `MessagesViewModelTests`'
shared helper put `"test key"` in every message key, which now legitimately matches a
`"test"` filter, so the helper key was renamed to keep those tests exercising body
matching. Two `SaveTopicSettings` fixtures added messages without a `Topic`, which
production never does — they now set it.

## Known limitation (pre-existing, not addressed here)

`ConsumerBase.GetMessageStream` begins producing before the caller attaches its
`CollectionChanged` handler, so messages landing in that window are missed by the UI. This
predates the change and the window is unchanged in width; multi-topic just makes it
slightly more visible. A correct fix needs a per-stream high-water mark keyed on
`NewStartingIndex` and belongs in its own change.

## Reviewer notes

- `ViewModels/OpenedClusterViewModel.Fetching.cs` — the substantive rewrite, worth reading first
- `ViewModels/Search/` — filter interface change
- `ViewModels/OpenedClusterViewModel.Topics.cs` — check/uncheck orchestration
- `ITreeNode.IsChecked` / `IsCheckable` are default interface members so partition and
  cluster nodes need no changes